### PR TITLE
Cli FIX #20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ clap = "2.33.0"
 color-backtrace = "0.2.3"
 rustyline = "5.0.4"
 app_dirs = "1.2.1"
+yansi = "0.5.0"
 rtrees = {path = "rtrees"}
 rio = {path = "rio"}
 rcmd = {path = "rcmd"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ path = "src/rair.rs"
 clap = "2.33.0"
 color-backtrace = "0.2.3"
 rustyline = "5.0.3"
+app_dirs = "1.2.1"
 rtrees = {path = "rtrees"}
 rio = {path = "rio"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "rcore",
   "rio",
   "rtrees",
+  "test_file",
 ]
 [package]
 name = "rair-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "rcmd",
+  "rcore",
   "rio",
   "rtrees",
 ]
@@ -22,8 +23,9 @@ path = "src/rair.rs"
 [dependencies]
 clap = "2.33.0"
 color-backtrace = "0.2.3"
-rustyline = "5.0.3"
+rustyline = "5.0.4"
 app_dirs = "1.2.1"
 rtrees = {path = "rtrees"}
 rio = {path = "rio"}
 rcmd = {path = "rcmd"}
+rcore = {path = "rcore"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/rair.rs"
 
 [dependencies]
 clap = "2.33.0"
+color-backtrace = "0.2.3"
 rustyline = "5.0.3"
 rtrees = {path = "rtrees"}
 rio = {path = "rio"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/rair.rs"
 
 [dependencies]
 clap = "2.33.0"
-color-backtrace = "0.2.3"
 rustyline = "5.0.4"
 app_dirs = "1.2.1"
 yansi = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "rcmd",
   "rio",
   "rtrees",
 ]
@@ -19,3 +20,4 @@ rustyline = "5.0.3"
 app_dirs = "1.2.1"
 rtrees = {path = "rtrees"}
 rio = {path = "rio"}
+rcmd = {path = "rcmd"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ name = "rair"
 path = "src/rair.rs"
 
 [dependencies]
+clap = "2.33.0"
+rustyline = "5.0.3"
+rtrees = {path = "rtrees"}
+rio = {path = "rio"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,14 @@ members = [
 ]
 [package]
 name = "rair-core"
+description = "Reverse Engineering framework written in rust."
 version = "0.1.0"
 authors = ["oddcoder <ahmedsoliman@oddcoder.com>"]
+license = "LGPL"
+repository = "https://github.com/oddcoder/rair"
+readme = "README.md"
+keywords = ["Reverse Engineering", "Assembly", "Disassembly", "Malware", "Static Analysis"]
+categories = ["command-line-utilities", "Reverse-Engineering"]
 
 [[bin]]
 name = "rair"

--- a/rcmd/Cargo.toml
+++ b/rcmd/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rcmd"
+version = "0.1.0"
+authors = ["oddcoder <ahmedsoliman@oddcoder.com>"]
+license = "LGPL"
+repository = "https://github.com/oddcoder/rair"
+keywords = ["Parser", "cmd", "Command Line"]
+description = "IO subsystem for RAIR"
+categories = ["CLI"]
+readme = "readme.md"
+
+
+
+[dependencies]
+pest = "2.1.2"
+pest_derive = "2.1.0"
+err-derive = "0.2.1"
+

--- a/rcmd/readme.md
+++ b/rcmd/readme.md
@@ -1,0 +1,4 @@
+RCmd
+===
+
+RPEL for rair

--- a/rcmd/src/cli.pest
+++ b/rcmd/src/cli.pest
@@ -1,0 +1,88 @@
+/*
+ * cli.pest: Rair RPEL grammar.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Auxillary types
+
+WHITESPACE = _{ " " | "\t" }
+CustomAlpha = _{ASCII_ALPHA | "_"}
+CustomAlphaNum = _{ASCII_ALPHANUMERIC | "_"}
+// Alpha Numerics with White space and some Symbols
+ANWS = {
+    WHITESPACE | ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "@" | "#" | "$" |
+    "%" | "^" | "&" | "*" | "(" | ")" | "_" | "+" | "="
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+// Numeric Types
+
+
+DEC = @{
+    ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*
+}
+
+BIN = @{
+    "0b" ~ ASCII_BIN_DIGIT+
+}
+
+HEX = @{
+    "0x" ~ ASCII_HEX_DIGIT+
+}
+
+OCT = @{
+    "0" ~ ASCII_OCT_DIGIT+
+}
+///////////////////////////////////////////////////////////////////////////////
+
+// Command Line Interface grammar
+
+Command = @{CustomAlpha ~ CustomAlphaNum*}
+Argument = {
+    CustomAlphaNum+ |
+    "\"" ~ ANWS+ ~"\"" |
+    "`" ~ CommandLine ~ "`"
+}
+Arguments = {
+    Argument+
+}
+
+Loc = {
+    "@" ~ DEC |
+    "@" ~ BIN |
+    "@" ~ HEX |
+    "@" ~ OCT
+}
+Pipe = {"|"}
+Red = {">"}
+RedCat = {">>"}
+RedPipe = {
+    Pipe ~ Argument |
+    Red ~ Argument |
+    RedCat ~ Argument 
+}
+
+Comment = {"#" ~ ANY*}
+EmptyLine = {""}
+HelpLine = {Command ~ "?"}
+CommandLine = {Command ~ Arguments? ~ Loc? ~ RedPipe?}
+
+Input = {
+    SOI ~ CommandLine ~ Comment? ~ EOI |
+    SOI ~ HelpLine ~ Comment? ~ EOI |
+    SOI ~ EmptyLine ~ EOI |
+    SOI ~ Comment ~ EOI
+    
+}

--- a/rcmd/src/cli.pest
+++ b/rcmd/src/cli.pest
@@ -20,9 +20,10 @@
 WHITESPACE = _{ " " | "\t" }
 CustomAlpha = _{ASCII_ALPHA | "_"}
 CustomAlphaNum = _{ASCII_ALPHANUMERIC | "_"}
-// Alpha Numerics with White space and some Symbols except "@ or #"
+// Alpha Numerics with some Symbols except "@ or #"
 ANS = {ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "$" |
     "%" | "^" | "&" | "*" | "(" | ")" | "_" | "+" | "=" | "-"}
+// Alpha Numerics with White space and Symbols
 ANWS = { WHITESPACE |ANS | "@" | "#"}
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -49,8 +50,9 @@ OCT = @{
 // Command Line Interface grammar
 
 Command = @{CustomAlpha ~ CustomAlphaNum*}
+ArgumentLiteral = ${ANS+}
 Argument = {
-    ANS+ |
+    ArgumentLiteral |
     "\"" ~ ANWS+ ~"\"" |
     "`" ~ CommandLine ~ "`"
 }

--- a/rcmd/src/cli.pest
+++ b/rcmd/src/cli.pest
@@ -21,10 +21,9 @@ WHITESPACE = _{ " " | "\t" }
 CustomAlpha = _{ASCII_ALPHA | "_"}
 CustomAlphaNum = _{ASCII_ALPHANUMERIC | "_"}
 // Alpha Numerics with White space and some Symbols
-ANWS = {
-    WHITESPACE | ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "@" | "#" | "$" |
-    "%" | "^" | "&" | "*" | "(" | ")" | "_" | "+" | "="
-}
+ANS = {ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "@" | "#" | "$" |
+    "%" | "^" | "&" | "*" | "(" | ")" | "_" | "+" | "=" | "-"}
+ANWS = { WHITESPACE |ANS }
 
 //////////////////////////////////////////////////////////////////////////////////
 // Numeric Types
@@ -51,7 +50,7 @@ OCT = @{
 
 Command = @{CustomAlpha ~ CustomAlphaNum*}
 Argument = {
-    CustomAlphaNum+ |
+    ANS+ |
     "\"" ~ ANWS+ ~"\"" |
     "`" ~ CommandLine ~ "`"
 }

--- a/rcmd/src/cli.pest
+++ b/rcmd/src/cli.pest
@@ -20,10 +20,10 @@
 WHITESPACE = _{ " " | "\t" }
 CustomAlpha = _{ASCII_ALPHA | "_"}
 CustomAlphaNum = _{ASCII_ALPHANUMERIC | "_"}
-// Alpha Numerics with White space and some Symbols
-ANS = {ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "@" | "#" | "$" |
+// Alpha Numerics with White space and some Symbols except "@ or #"
+ANS = {ASCII_ALPHANUMERIC | "/" | "\\" | "~" | "!" | "$" |
     "%" | "^" | "&" | "*" | "(" | ")" | "_" | "+" | "=" | "-"}
-ANWS = { WHITESPACE |ANS }
+ANWS = { WHITESPACE |ANS | "@" | "#"}
 
 //////////////////////////////////////////////////////////////////////////////////
 // Numeric Types

--- a/rcmd/src/cli.pest
+++ b/rcmd/src/cli.pest
@@ -70,9 +70,9 @@ Pipe = {"|"}
 Red = {">"}
 RedCat = {">>"}
 RedPipe = {
-    Pipe ~ Argument |
+    Pipe ~ Argument+ |
     Red ~ Argument |
-    RedCat ~ Argument 
+    RedCat ~ Argument
 }
 
 Comment = {"#" ~ ANY*}

--- a/rcmd/src/cmd.rs
+++ b/rcmd/src/cmd.rs
@@ -1,0 +1,124 @@
+/*
+ * cmd.rs: Main command parsing.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use error::ParserError;
+use grammar::*;
+use pest::iterators::Pair;
+
+#[derive(Debug)]
+pub enum RedPipe {
+    None,
+    Redirect(Argument),
+    RedirectCat(Argument),
+    Pipe(Argument),
+}
+
+impl Default for RedPipe {
+    fn default() -> Self {
+        return RedPipe::None;
+    }
+}
+impl RedPipe {
+    fn parse_pipe(root: Pair<Rule>) -> Self {
+        let mut pairs = root.into_inner();
+        let type_identifier = pairs.next().unwrap();
+        let arg = Argument::parse_argument(pairs.next().unwrap());
+        return match type_identifier.as_rule() {
+            Rule::Pipe => RedPipe::Pipe(arg),
+            Rule::Red => RedPipe::Redirect(arg),
+            Rule::RedCat => RedPipe::RedirectCat(arg),
+            _ => {
+                println!("{:#?}", type_identifier);
+                unimplemented!();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Argument {
+    NonLiteral(Cmd),
+    Literal(String),
+    Err(ParserError),
+}
+impl Argument {
+    fn parse_arguments(root: Pair<Rule>) -> Vec<Self> {
+        assert_eq!(root.as_rule(), Rule::Arguments);
+        let mut args = Vec::new();
+        for pair in root.into_inner() {
+            args.push(Argument::parse_argument(pair));
+        }
+        return args;
+    }
+    fn parse_argument(root: Pair<Rule>) -> Self {
+        let arg = root.as_str();
+        if arg.starts_with("`") && arg.ends_with("`") {
+                let res = Cmd::parse_cmd(root.into_inner().next().unwrap());
+                match res {
+                    Ok(cmd) => return Argument::NonLiteral(cmd),
+                    Err(e) => return Argument::Err(e),
+                }
+            } else if arg.starts_with("\"") && arg.ends_with("\"") {
+                return Argument::Literal(arg[1..arg.len()-1].to_owned());
+            } else {
+                return Argument::Literal(arg.to_owned());
+            }
+    }
+}
+#[derive(Default, Debug)]
+pub struct Cmd {
+    pub command: String,
+    pub args: Vec<Argument>,
+    pub loc: Option<u64>,
+    pub red_pipe: Box<RedPipe>,
+}
+
+fn pair_to_num(root: Pair<Rule>) -> Result<u64, ParserError> {
+    let result = match root.as_rule() {
+        Rule::BIN => u64::from_str_radix(&root.as_str()[2..], 2),
+        Rule::HEX => u64::from_str_radix(&root.as_str()[2..], 16),
+        Rule::OCT => u64::from_str_radix(&root.as_str()[1..], 8),
+        Rule::DEC => u64::from_str_radix(root.as_str(), 10),
+        _ => {
+            println!("{:#?}", root);
+            unimplemented!();
+        }
+    };
+    match result {
+        Ok(x) => return Ok(x),
+        Err(e) => return Err(ParserError::Num(e)),
+    }
+}
+impl Cmd {
+    pub fn parse_cmd(root: Pair<Rule>) -> Result<Self, ParserError> {
+        assert_eq!(root.as_rule(), Rule::CommandLine);
+        let mut cmd: Cmd = Default::default();
+        for pair in root.into_inner() {
+            match pair.as_rule() {
+                Rule::Command => cmd.command = pair.as_str().to_owned(),
+                Rule::Loc => cmd.loc = Some(pair_to_num(pair.into_inner().next().unwrap())?),
+                Rule::Arguments => cmd.args = Argument::parse_arguments(pair),
+                Rule::RedPipe => cmd.red_pipe = Box::new(RedPipe::parse_pipe(pair)),
+                _ => {
+                    println!("{:#?}", pair);
+                    unimplemented!();
+                }
+            }
+        }
+        return Ok(cmd);
+    }
+}

--- a/rcmd/src/cmd.rs
+++ b/rcmd/src/cmd.rs
@@ -225,11 +225,7 @@ mod test_normal_cmd {
 
         root = CliParser::parse(Rule::CommandLine, "aa | ls -lah").unwrap().next().unwrap();
         cmd = Cmd::parse_cmd(root).unwrap();
-        target.red_pipe = Box::new(RedPipe::Pipe(vec![
-            Argument::Literal("ls".to_string()),
-            Argument::Literal("-lah".to_string()),
-        ]));
+        target.red_pipe = Box::new(RedPipe::Pipe(vec![Argument::Literal("ls".to_string()), Argument::Literal("-lah".to_string())]));
         assert_eq!(cmd, target);
-
     }
 }

--- a/rcmd/src/cmd.rs
+++ b/rcmd/src/cmd.rs
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use error::ParserError;
+use error::*;
 use grammar::*;
 use pest::iterators::Pair;
 
@@ -52,10 +52,7 @@ impl RedPipe {
                 let arg = Argument::parse_argument(pairs.next().unwrap());
                 return RedPipe::RedirectCat(Box::new(arg));
             }
-            _ => {
-                println!("{:#?}", type_identifier);
-                unimplemented!();
-            }
+            _ => unimplemented_pair(type_identifier),
         };
     }
 }
@@ -104,10 +101,7 @@ fn pair_to_num(root: Pair<Rule>) -> Result<u64, ParserError> {
         Rule::HEX => u64::from_str_radix(&root.as_str()[2..], 16),
         Rule::OCT => u64::from_str_radix(&root.as_str()[1..], 8),
         Rule::DEC => u64::from_str_radix(root.as_str(), 10),
-        _ => {
-            println!("{:#?}", root);
-            unimplemented!();
-        }
+        _ => unimplemented_pair(root),
     };
     match result {
         Ok(x) => return Ok(x),
@@ -124,10 +118,7 @@ impl Cmd {
                 Rule::Loc => cmd.loc = Some(pair_to_num(pair.into_inner().next().unwrap())?),
                 Rule::Arguments => cmd.args = Argument::parse_arguments(pair),
                 Rule::RedPipe => cmd.red_pipe = Box::new(RedPipe::parse_pipe(pair)),
-                _ => {
-                    println!("{:#?}", pair);
-                    unimplemented!();
-                }
+                _ => unimplemented_pair(pair),
             }
         }
         return Ok(cmd);

--- a/rcmd/src/cmd.rs
+++ b/rcmd/src/cmd.rs
@@ -152,6 +152,16 @@ mod test_normal_cmd {
         }));
         assert_eq!(cmd, target);
     }
+    #[test]
+    fn test_cmd_argument_bug() {
+        let root = CliParser::parse(Rule::CommandLine, "aa bb cc").unwrap().next().unwrap();
+        let cmd = Cmd::parse_cmd(root).unwrap();
+        let mut target: Cmd = Default::default();
+        target.command = "aa".to_string();
+        target.args.push(Argument::Literal("bb".to_string()));
+        target.args.push(Argument::Literal("cc".to_string()));
+        assert_eq!(cmd, target);
+    }
 
     #[test]
     fn test_cmd_loc() {

--- a/rcmd/src/error.rs
+++ b/rcmd/src/error.rs
@@ -1,0 +1,27 @@
+/*
+ * error.rs: rcmd Error handling mechanism.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use err_derive::Error;
+use std::num;
+use pest::error;
+use grammar::Rule;
+#[derive(Debug, Error)]
+pub enum ParserError {
+    #[error(display = "{})", _0)]
+    Num(num::ParseIntError),
+    #[error(display = "{})", _0)]
+    Pest(error::Error<Rule>),
+}

--- a/rcmd/src/error.rs
+++ b/rcmd/src/error.rs
@@ -17,11 +17,18 @@
 use err_derive::Error;
 use grammar::Rule;
 use pest::error;
+use pest::iterators::Pair;
 use std::num;
+
 #[derive(Debug, Error, PartialEq)]
 pub enum ParserError {
     #[error(display = "{})", _0)]
     Num(num::ParseIntError),
     #[error(display = "{})", _0)]
     Pest(error::Error<Rule>),
+}
+
+pub fn unimplemented_pair(root: Pair<Rule>) -> ! {
+    println!("{:#?}", root);
+    unimplemented!();
 }

--- a/rcmd/src/error.rs
+++ b/rcmd/src/error.rs
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use err_derive::Error;
-use std::num;
-use pest::error;
 use grammar::Rule;
-#[derive(Debug, Error)]
+use pest::error;
+use std::num;
+#[derive(Debug, Error, PartialEq)]
 pub enum ParserError {
     #[error(display = "{})", _0)]
     Num(num::ParseIntError),

--- a/rcmd/src/grammar.rs
+++ b/rcmd/src/grammar.rs
@@ -1,0 +1,19 @@
+/*
+ * grammar.rs: Deriving grammar for rair from cli.pest.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#[derive(Parser)]
+#[grammar = "cli.pest"]
+pub(crate) struct CliParser;

--- a/rcmd/src/help.rs
+++ b/rcmd/src/help.rs
@@ -18,7 +18,7 @@
 use grammar::Rule;
 use pest::iterators::Pair;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, PartialEq)]
 pub struct HelpCmd {
     pub command: String,
 }
@@ -29,5 +29,24 @@ impl HelpCmd {
         HelpCmd {
             command: root.into_inner().next().unwrap().as_str().to_owned(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test_help_cmd {
+    use super::*;
+    use grammar::CliParser;
+    use pest::Parser;
+    #[test]
+    fn test_help_no_space() {
+        let root = CliParser::parse(Rule::HelpLine, "aa?").unwrap().next().unwrap();
+        let help = HelpCmd::parse_help(root);
+        assert_eq!(help, HelpCmd { command: "aa".to_string() });
+    }
+    #[test]
+    fn test_help_space() {
+        let root = CliParser::parse(Rule::HelpLine, "aa          ?").unwrap().next().unwrap();
+        let help = HelpCmd::parse_help(root);
+        assert_eq!(help, HelpCmd { command: "aa".to_string() });
     }
 }

--- a/rcmd/src/help.rs
+++ b/rcmd/src/help.rs
@@ -1,0 +1,33 @@
+/*
+ * help.rs: Help part of AST.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use grammar::Rule;
+use pest::iterators::Pair;
+
+#[derive(Default, Debug)]
+pub struct HelpCmd {
+    pub command: String,
+}
+
+impl HelpCmd {
+    pub(crate) fn parse_help(root: Pair<Rule>) -> Self {
+        assert_eq!(root.as_rule(), Rule::HelpLine);
+        HelpCmd {
+            command: root.into_inner().next().unwrap().as_str().to_owned(),
+        }
+    }
+}

--- a/rcmd/src/lib.rs
+++ b/rcmd/src/lib.rs
@@ -22,9 +22,11 @@ extern crate pest_derive;
 extern crate err_derive;
 extern crate pest;
 
-mod parser;
+mod cmd;
+mod error;
 mod grammar;
 mod help;
-mod error;
-mod cmd;
+mod parser;
+pub use cmd::*;
+pub use help::*;
 pub use parser::*;

--- a/rcmd/src/lib.rs
+++ b/rcmd/src/lib.rs
@@ -1,0 +1,30 @@
+#![warn(clippy::cargo)]
+#![allow(clippy::needless_return)]
+/*
+ * rcmd: rair RPEL impelementation
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#[macro_use]
+extern crate pest_derive;
+extern crate err_derive;
+extern crate pest;
+
+mod parser;
+mod grammar;
+mod help;
+mod error;
+mod cmd;
+pub use parser::*;

--- a/rcmd/src/lib.rs
+++ b/rcmd/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
 /*
  * rcmd: rair RPEL impelementation

--- a/rcmd/src/parser.rs
+++ b/rcmd/src/parser.rs
@@ -14,13 +14,13 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-use pest::Parser;
-use help::HelpCmd;
-use grammar::*;
-use error::ParserError;
 use cmd::Cmd;
+use error::ParserError;
+use grammar::*;
+use help::HelpCmd;
+use pest::Parser;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ParseTree {
     Help(HelpCmd),
     Cmd(Cmd),
@@ -47,5 +47,24 @@ impl ParseTree {
             }
         }
         return Ok(ParseTree::Comment);
+    }
+}
+
+#[cfg(test)]
+mod test_parser {
+    use super::*;
+    #[test]
+    fn test_parser() {
+        let mut tree = ParseTree::construct("aa? #and a little comment").unwrap();
+        assert_eq!(tree, ParseTree::Help(HelpCmd { command: "aa".to_string() }));
+        assert!(ParseTree::construct("aa withargument? #and a little comment").is_err());
+        tree = ParseTree::construct("aa #and a little comment").unwrap();
+        let mut cmd: Cmd = Default::default();
+        cmd.command = "aa".to_string();
+        assert_eq!(tree, ParseTree::Cmd(cmd));
+        tree = ParseTree::construct("#and a little comment").unwrap();
+        assert_eq!(tree, ParseTree::Comment);
+        tree = ParseTree::construct("").unwrap();
+        assert_eq!(tree, ParseTree::NewLine);
     }
 }

--- a/rcmd/src/parser.rs
+++ b/rcmd/src/parser.rs
@@ -34,19 +34,17 @@ impl ParseTree {
         if pairs.is_err() {
             return Err(ParserError::Pest(pairs.err().unwrap()));
         }
-        for pair in pairs.unwrap().next().unwrap().into_inner() {
-            match pair.as_rule() {
-                Rule::HelpLine => return Ok(ParseTree::Help(HelpCmd::parse_help(pair))),
-                Rule::Comment => return Ok(ParseTree::Comment),
-                Rule::EmptyLine => return Ok(ParseTree::NewLine),
-                Rule::CommandLine => return Ok(ParseTree::Cmd(Cmd::parse_cmd(pair)?)),
-                _ => {
-                    println!("{:#?}", pair);
-                    unimplemented!();
-                }
+        let pair = pairs.unwrap().next().unwrap().into_inner().next().unwrap();
+        match pair.as_rule() {
+            Rule::HelpLine => return Ok(ParseTree::Help(HelpCmd::parse_help(pair))),
+            Rule::Comment => return Ok(ParseTree::Comment),
+            Rule::EmptyLine => return Ok(ParseTree::NewLine),
+            Rule::CommandLine => return Ok(ParseTree::Cmd(Cmd::parse_cmd(pair)?)),
+            _ => {
+                println!("{:#?}", pair);
+                unimplemented!();
             }
         }
-        return Ok(ParseTree::Comment);
     }
 }
 

--- a/rcmd/src/parser.rs
+++ b/rcmd/src/parser.rs
@@ -15,11 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 use cmd::Cmd;
-use error::ParserError;
+use error::*;
 use grammar::*;
 use help::HelpCmd;
 use pest::Parser;
-
 #[derive(Debug, PartialEq)]
 pub enum ParseTree {
     Help(HelpCmd),
@@ -40,10 +39,7 @@ impl ParseTree {
             Rule::Comment => return Ok(ParseTree::Comment),
             Rule::EmptyLine => return Ok(ParseTree::NewLine),
             Rule::CommandLine => return Ok(ParseTree::Cmd(Cmd::parse_cmd(pair)?)),
-            _ => {
-                println!("{:#?}", pair);
-                unimplemented!();
-            }
+            _ => unimplemented_pair(pair),
         }
     }
 }

--- a/rcmd/src/parser.rs
+++ b/rcmd/src/parser.rs
@@ -1,0 +1,51 @@
+/*
+ * parser.rs: Generate AST like structure for rair commands.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use pest::Parser;
+use help::HelpCmd;
+use grammar::*;
+use error::ParserError;
+use cmd::Cmd;
+
+#[derive(Debug)]
+pub enum ParseTree {
+    Help(HelpCmd),
+    Cmd(Cmd),
+    Comment,
+    NewLine,
+}
+
+impl ParseTree {
+    pub fn construct(line: &str) -> Result<Self, ParserError> {
+        let pairs = CliParser::parse(Rule::Input, line);
+        if pairs.is_err() {
+            return Err(ParserError::Pest(pairs.err().unwrap()));
+        }
+        for pair in pairs.unwrap().next().unwrap().into_inner() {
+            match pair.as_rule() {
+                Rule::HelpLine => return Ok(ParseTree::Help(HelpCmd::parse_help(pair))),
+                Rule::Comment => return Ok(ParseTree::Comment),
+                Rule::EmptyLine => return Ok(ParseTree::NewLine),
+                Rule::CommandLine => return Ok(ParseTree::Cmd(Cmd::parse_cmd(pair)?)),
+                _ => {
+                    println!("{:#?}", pair);
+                    unimplemented!();
+                }
+            }
+        }
+        return Ok(ParseTree::Comment);
+    }
+}

--- a/rcore/Cargo.toml
+++ b/rcore/Cargo.toml
@@ -14,6 +14,7 @@ readme = "readme.md"
 [dependencies]
 app_dirs = "1.2.1"
 rustyline = "5.0.4"
+yansi = "0.5.0"
 
 rio = {path = "../rio"}
 rtrees = {path = "../rtrees"}

--- a/rcore/Cargo.toml
+++ b/rcore/Cargo.toml
@@ -20,3 +20,7 @@ yansi = "0.5.0"
 rio = {path = "../rio"}
 rtrees = {path = "../rtrees"}
 rcmd = {path = "../rcmd"}
+
+[dev-dependencies]
+
+test_file = {path = "../test_file"}

--- a/rcore/Cargo.toml
+++ b/rcore/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rcore"
+version = "0.1.0"
+authors = ["oddcoder <ahmedsoliman@oddcoder.com>"]
+license = "LGPL"
+repository = "https://github.com/oddcoder/rair"
+keywords = ["Rair", "Core"]
+description = "Core module for Rair"
+categories = ["CLI"]
+readme = "readme.md"
+
+
+
+[dependencies]
+app_dirs = "1.2.1"
+rustyline = "5.0.4"
+
+rio = {path = "../rio"}
+rtrees = {path = "../rtrees"}
+

--- a/rcore/Cargo.toml
+++ b/rcore/Cargo.toml
@@ -14,8 +14,9 @@ readme = "readme.md"
 [dependencies]
 app_dirs = "1.2.1"
 rustyline = "5.0.4"
+rustyline-derive = "0.2.0"
 yansi = "0.5.0"
 
 rio = {path = "../rio"}
 rtrees = {path = "../rtrees"}
-
+rcmd = {path = "../rcmd"}

--- a/rcore/readme.md
+++ b/rcore/readme.md
@@ -1,0 +1,4 @@
+RCore
+===
+
+Core module for rair

--- a/rcore/src/commands.rs
+++ b/rcore/src/commands.rs
@@ -17,11 +17,7 @@
 
 use helper::*;
 use rtrees::bktree::SpellTree;
-use std::cell::RefCell;
 use std::collections::BTreeMap; // for suffex search
-use std::rc::Rc;
-
-pub type MRc<T> = Rc<RefCell<T>>; //mutable refcounter
 
 #[derive(Default)]
 pub struct Commands {

--- a/rcore/src/commands.rs
+++ b/rcore/src/commands.rs
@@ -1,0 +1,50 @@
+/*
+ * commands.rs: Data Structure for holding rair commands.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use helper::*;
+use rtrees::bktree::SpellTree;
+use std::collections::BTreeMap; // for suffex search
+
+#[derive(Default)]
+pub struct Commands {
+    suggestions: SpellTree<()>,
+    search: BTreeMap<&'static str, &'static CmdFunctions>,
+}
+
+impl Commands {
+    // Returns false if the command with the same name exists
+    pub fn add_command(&mut self, command_name: &'static str, functionality: &'static CmdFunctions) -> bool {
+        // first check that command_name doesn't exist
+        if self.search.contains_key(command_name) {
+            return false;
+        } else {
+            self.suggestions.insert(command_name.to_string(), ());
+            self.search.insert(command_name, functionality);
+            return true;
+        }
+    }
+
+    pub fn find(&self, command: &str) -> Option<&&CmdFunctions> {
+        return self.search.get(command);
+    }
+    pub fn suggest(&self, command: &str, tolerance: u64) -> Vec<&String> {
+        return self.suggestions.find(&command.to_string(), tolerance).1;
+    }
+    pub fn prefix<'a>(&'a self, command: &'a str) -> Vec<&&str> {
+        return self.search.range(command..).take_while(|(k, _)| k.starts_with(command)).map(|(k, _)| k).collect();
+    }
+}

--- a/rcore/src/commands.rs
+++ b/rcore/src/commands.rs
@@ -22,12 +22,12 @@ use std::collections::BTreeMap; // for suffex search
 #[derive(Default)]
 pub struct Commands {
     suggestions: SpellTree<()>,
-    search: BTreeMap<&'static str, &'static CmdFunctions>,
+    search: BTreeMap<&'static str, Box<dyn Cmd>>,
 }
 
 impl Commands {
     // Returns false if the command with the same name exists
-    pub fn add_command(&mut self, command_name: &'static str, functionality: &'static CmdFunctions) -> bool {
+    pub fn add_command(&mut self, command_name: &'static str, functionality: Box<dyn Cmd>) -> bool {
         // first check that command_name doesn't exist
         if self.search.contains_key(command_name) {
             return false;
@@ -38,8 +38,11 @@ impl Commands {
         }
     }
 
-    pub fn find(&self, command: &str) -> Option<&&CmdFunctions> {
-        return self.search.get(command);
+    pub fn find(&self, command: &str) -> Option<&dyn Cmd> {
+        return self.search.get(command).map(|cmd| &**cmd);
+    }
+    pub fn find_mut(&mut self, command: &str) -> Option<&mut dyn Cmd> {
+        return self.search.get_mut(command).map(|cmd| &mut **cmd as &mut dyn Cmd);
     }
     pub fn suggest(&self, command: &str, tolerance: u64) -> Vec<&String> {
         return self.suggestions.find(&command.to_string(), tolerance).1;

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -136,12 +136,11 @@ impl Core {
         let cmds = self.commands.clone();
         let cmds_ref = cmds.borrow_mut();
         let cmd = cmds_ref.find(&command.to_string());
-        match cmd {
-            Some(cmd) => cmd.borrow_mut().run(self, args),
-            None => {
-                drop(cmds_ref);
-                self.command_not_found(command)
-            }
+        if let Some(cmd) = cmd {
+            cmd.borrow_mut().run(self, args);
+        } else {
+            drop(cmds_ref);
+            self.command_not_found(command)
         }
     }
 
@@ -155,12 +154,11 @@ impl Core {
         let cmds = self.commands.clone();
         let cmds_ref = cmds.borrow();
         let cmd = cmds_ref.find(&command.to_string());
-        match cmd {
-            Some(cmd) => cmd.borrow().help(self),
-            None => {
-                drop(cmds_ref);
-                self.command_not_found(command);
-            }
+        if let Some(cmd) = cmd {
+            cmd.borrow().help(self);
+        } else {
+            drop(cmds_ref);
+            self.command_not_found(command);
         }
     }
 }

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -16,7 +16,7 @@
  */
 
 use app_dirs::*;
-use commands::{Commands, MRc};
+use commands::Commands;
 use helper::*;
 use io::*;
 use lineformatter::LineFormatter;

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -27,30 +27,10 @@ use std::io;
 use std::io::Write;
 use std::mem;
 use std::path::PathBuf;
-
+pub use writer::Writer;
 pub struct CmdFunctions {
     pub run: fn(&mut Core, &Vec<String>),
     pub help: fn(&mut Core),
-}
-
-pub enum Writer {
-    Write(Box<dyn Write>),
-    Bytes(Vec<u8>),
-}
-
-impl Write for Writer {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self {
-            Writer::Write(writer) => writer.write(buf),
-            Writer::Bytes(bytes) => bytes.write(buf),
-        }
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        match self {
-            Writer::Write(writer) => writer.flush(),
-            Writer::Bytes(bytes) => bytes.flush(),
-        }
-    }
 }
 
 pub enum AddrMode {
@@ -99,8 +79,8 @@ impl Core {
     pub fn new() -> Self {
         let mut core = Core {
             mode: AddrMode::Phy,
-            stdout: Writer::Write(Box::new(io::stdout())),
-            stderr: Writer::Write(Box::new(io::stderr())),
+            stdout: Writer::new_write(Box::new(io::stdout())),
+            stderr: Writer::new_write(Box::new(io::stderr())),
             io: RIO::new(),
             loc: 0,
             rl: Editor::<()>::new(),

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -18,9 +18,9 @@
 use app_dirs::*;
 use commands::Commands;
 use helper::*;
-use io::{LISTMAPFUNCTION, MAPFUNCTION, PRINTHEXFUNCTION, UNMAPFUNCTION};
+use io::*;
 use lineformatter::LineFormatter;
-use loc::{MODEFUNCTION, SEEKFUNCTION};
+use loc::*;
 use rio::*;
 use rustyline::{CompletionType, Config, EditMode, Editor, OutputStreamType};
 use std::cell::RefCell;
@@ -29,6 +29,7 @@ use std::io::Write;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
+use utils::*;
 use writer::Writer;
 use yansi::Paint;
 pub struct Core {
@@ -70,6 +71,8 @@ impl Core {
         self.add_command("s", &SEEKFUNCTION);
         self.add_command("unmap", &UNMAPFUNCTION);
         self.add_command("um", &UNMAPFUNCTION);
+        self.add_command("quit", &QUITFUNCTION);
+        self.add_command("q", &QUITFUNCTION);
     }
     fn init_colors(&mut self) {
         self.color_palette.push((0x58, 0x68, 0x75));

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -17,7 +17,7 @@
 
 use app_dirs::*;
 use helper::*;
-use io::PRINTHEXFUNCTION;
+use io::{LISTMAPFUNCTION, MAPFUNCTION, PRINTHEXFUNCTION, UNMAPFUNCTION};
 use loc::{MODEFUNCTION, SEEKFUNCTION};
 use rio::*;
 use rtrees::bktree::SpellTree;
@@ -57,12 +57,17 @@ impl Default for Core {
 }
 impl Core {
     fn load_commands(&mut self) {
+        self.add_command("map", &MAPFUNCTION);
+        self.add_command("maps", &LISTMAPFUNCTION);
         self.add_command("mode", &MODEFUNCTION);
         self.add_command("m", &MODEFUNCTION);
         self.add_command("printHex", &PRINTHEXFUNCTION);
         self.add_command("px", &PRINTHEXFUNCTION);
         self.add_command("seek", &SEEKFUNCTION);
         self.add_command("s", &SEEKFUNCTION);
+        self.add_command("unmap", &UNMAPFUNCTION);
+        self.add_command("um", &UNMAPFUNCTION);
+        
     }
     fn init_colors(&mut self) {
         self.color_palette.push((0x58, 0x68, 0x75));

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -188,6 +188,10 @@ mod test_core {
         core.stdout = Writer::new_buf();
         core.add_command("test_command", "s", Rc::new(RefCell::new(Quit::new())));
         assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Cannot add this command.\nCommand s already existed.\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.add_command("seek", "test_stuff", Rc::new(RefCell::new(Quit::new())));
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Cannot add this command.\nCommand seek already existed.\n");
     }
     #[test]
     fn test_help() {
@@ -205,8 +209,11 @@ mod test_core {
         let mut core = Core::new();
         core.stderr = Writer::new_buf();
         core.stdout = Writer::new_buf();
-        core.run_at("seeker", &[], 0x500);
+        core.run_at("mep", &[], 0x500);
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
-        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Execution failed\nCommand seeker is not found.\nSimilar command: seek.\n");
+        assert_eq!(
+            core.stderr.utf8_string().unwrap(),
+            "Error: Execution failed\nCommand mep is not found.\nSimilar command: map, maps, m.\n"
+        );
     }
 }

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -104,7 +104,7 @@ impl Core {
         if exact.is_empty() {
             self.commands.insert(command, functionality);
         } else {
-            let msg = format!("Command {} already existed", Paint::default(command_name).bold());
+            let msg = format!("Command {} already existed.", Paint::default(command_name).bold());
             error_msg(self, "Cannot add this command.", &msg);
         }
     }
@@ -145,5 +145,50 @@ impl Core {
         } else {
             (exact[0].help)(self);
         }
+    }
+}
+
+#[cfg(test)]
+mod test_core {
+    use super::*;
+    #[test]
+    fn test_loc() {
+        let mut core = Core::new();
+        core.set_loc(0x500);
+        assert_eq!(core.get_loc(), 0x500);
+    }
+    #[test]
+    fn test_add_command() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.add_command("a_non_existing_command", &SEEKFUNCTION);
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.add_command("s", &SEEKFUNCTION);
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Cannot add this command.\nCommand s already existed.\n");
+    }
+    #[test]
+    fn test_help() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.help("seeker");
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Execution failed\nCommand seeker is not found.\nSimilar command: seek.\n");
+    }
+    #[test]
+    fn test_run_at() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.run_at("seeker", &[], 0x500);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Execution failed\nCommand seeker is not found.\nSimilar command: seek.\n");
     }
 }

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -1,0 +1,132 @@
+/*
+ * core.rs: Linking all rair parts together into 1 module.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use app_dirs::*;
+use rio::*;
+use rtrees::bktree::SpellTree;
+use rustyline::Editor;
+use std::io;
+use std::io::Write;
+use std::mem;
+use std::path::PathBuf;
+pub struct CmdFunctions {
+    run: &'static fn(&mut Core, &Vec<String>),
+    help: &'static fn(),
+}
+
+pub enum Writer {
+    Write(Box<dyn Write>),
+    Bytes(Vec<u8>),
+}
+
+impl Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Writer::Write(writer) => writer.write(buf),
+            Writer::Bytes(bytes) => bytes.write(buf),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Writer::Write(writer) => writer.flush(),
+            Writer::Bytes(bytes) => bytes.flush(),
+        }
+    }
+}
+
+pub struct Core {
+    pub stdout: Writer,
+    pub stderr: Writer,
+    pub io: RIO,
+    pub rl: Editor<()>,
+    loc: u64,
+    app_info: AppInfo,
+    commands: SpellTree<CmdFunctions>,
+}
+impl Core {
+    pub fn new() -> Self {
+        let mut core = Core {
+            stdout: Writer::Write(Box::new(io::stdout())),
+            stderr: Writer::Write(Box::new(io::stderr())),
+            io: RIO::new(),
+            loc: 0,
+            rl: Editor::<()>::new(),
+            app_info: AppInfo { name: "rair", author: "RairDevs" },
+            commands: SpellTree::new(),
+        };
+        drop(core.rl.load_history(&core.hist_file()));
+        return core;
+    }
+    pub fn hist_file(&self) -> PathBuf {
+        let mut history = app_dir(AppDataType::UserData, &self.app_info, "/").unwrap();
+        history.push("history");
+        return history;
+    }
+    pub fn set_loc(&mut self, loc: u64) {
+        self.loc = loc;
+    }
+    pub fn get_loc(&self) -> u64 {
+        self.loc
+    }
+    pub fn add_command(&mut self, command_name: &'static str, functionality: CmdFunctions) {
+        // first check that command_name doesn't exist
+        let command = command_name.to_string();
+        let (exact, _) = self.commands.find(&command, 0);
+        if exact.is_empty() {
+            self.commands.insert(command, functionality);
+        } else {
+            writeln!(self.stderr, "Command `{}` already existed", command_name).unwrap();
+        }
+    }
+    pub fn run(&mut self, command: &String, args: &Vec<String>) {
+        let (exact, similar) = self.commands.find(&command, 2);
+        if exact.is_empty() {
+            writeln!(self.stderr, "Command `{}` is not found.", command).unwrap();
+            let mut s = similar.iter();
+            if let Some(suggestion) = s.next() {
+                write!(self.stderr, "Similar command: {}", suggestion).unwrap();
+                for suggestion in s {
+                    write!(self.stderr, ", {}", suggestion).unwrap();
+                }
+                writeln!(self.stderr, ".").unwrap();
+            }
+        } else {
+            (exact[1].run)(self, args)
+        }
+    }
+    pub fn run_at(&mut self, command: &String, args: &Vec<String>, at: u64) {
+        let old_loc = mem::replace(&mut self.loc, at);
+        self.run(command, args);
+        self.loc = old_loc;
+    }
+    pub fn help(&mut self, command: &String) {
+        let (exact, similar) = self.commands.find(&command, 2);
+        if exact.is_empty() {
+            writeln!(self.stderr, "Command `{}` is not found", command).unwrap();
+            let mut s = similar.iter();
+            if let Some(suggestion) = s.next() {
+                write!(self.stderr, "Similar command: {}", suggestion).unwrap();
+                for suggestion in s {
+                    write!(self.stderr, ", {}", suggestion).unwrap();
+                }
+                writeln!(self.stderr, "").unwrap();
+            }
+        } else {
+            (exact[1].help)()
+        }
+    }
+}

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -67,7 +67,6 @@ impl Core {
         self.add_command("s", &SEEKFUNCTION);
         self.add_command("unmap", &UNMAPFUNCTION);
         self.add_command("um", &UNMAPFUNCTION);
-        
     }
     fn init_colors(&mut self) {
         self.color_palette.push((0x58, 0x68, 0x75));

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -79,7 +79,7 @@ impl Core {
     pub fn new() -> Self {
         let mut core: Core = Default::default();
         let config = Config::builder()
-            .completion_type(CompletionType::List)
+            .completion_type(CompletionType::Circular)
             .edit_mode(EditMode::Emacs)
             .output_stream(OutputStreamType::Stdout)
             .build();

--- a/rcore/src/core.rs
+++ b/rcore/src/core.rs
@@ -16,35 +16,18 @@
  */
 
 use app_dirs::*;
+use helper::*;
 use io::PRINTHEXFUNCTION;
 use loc::{MODEFUNCTION, SEEKFUNCTION};
 use rio::*;
 use rtrees::bktree::SpellTree;
 use rustyline::Editor;
-use std::fmt;
-use std::fmt::Display;
 use std::io;
 use std::io::Write;
 use std::mem;
 use std::path::PathBuf;
-pub use writer::Writer;
-pub struct CmdFunctions {
-    pub run: fn(&mut Core, &Vec<String>),
-    pub help: fn(&mut Core),
-}
+use writer::Writer;
 
-pub enum AddrMode {
-    Vir,
-    Phy,
-}
-impl Display for AddrMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AddrMode::Phy => write!(f, "Phy"),
-            AddrMode::Vir => write!(f, "Vir"),
-        }
-    }
-}
 pub struct Core {
     pub stdout: Writer,
     pub stderr: Writer,
@@ -93,17 +76,21 @@ impl Core {
         core.init_colors();
         return core;
     }
+
     pub fn hist_file(&self) -> PathBuf {
         let mut history = app_dir(AppDataType::UserData, &self.app_info, "/").unwrap();
         history.push("history");
         return history;
     }
+
     pub fn set_loc(&mut self, loc: u64) {
         self.loc = loc;
     }
+
     pub fn get_loc(&self) -> u64 {
         self.loc
     }
+
     pub fn add_command(&mut self, command_name: &'static str, functionality: &'static CmdFunctions) {
         // first check that command_name doesn't exist
         let command = command_name.to_string();
@@ -114,6 +101,7 @@ impl Core {
             writeln!(self.stderr, "Command `{}` already existed", command_name).unwrap();
         }
     }
+
     pub fn run(&mut self, command: &String, args: &Vec<String>) {
         let (exact, similar) = self.commands.find(&command, 2);
         if exact.is_empty() {
@@ -130,11 +118,13 @@ impl Core {
             (exact[0].run)(self, args)
         }
     }
+
     pub fn run_at(&mut self, command: &String, args: &Vec<String>, at: u64) {
         let old_loc = mem::replace(&mut self.loc, at);
         self.run(command, args);
         self.loc = old_loc;
     }
+
     pub fn help(&mut self, command: &String) {
         let (exact, similar) = self.commands.find(&command, 2);
         if exact.is_empty() {

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -75,7 +75,11 @@ pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) 
     };
     writeln!(core.stdout, "Usage:").unwrap();
     for (args, description) in usage {
-        writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, used), Paint::rgb(r2, g2, b2, args), description,).unwrap()
+        write!(core.stdout, "{}", Paint::rgb(r1, g1, b1, used)).unwrap();
+        if !args.is_empty() {
+            write!(core.stdout, " {}", Paint::rgb(r2, g2, b2, args)).unwrap();
+        }
+        writeln!(core.stdout, "\t{}", description,).unwrap()
     }
 }
 

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -30,7 +30,7 @@ pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
             _ => (),
         }
     }
-    if n.chars().nth(0).unwrap() == '0' {
+    if n.chars().nth(0).unwrap() == '0' && n.len() > 1 {
         return u64::from_str_radix(&n[1..], 8);
     }
     return u64::from_str_radix(n, 10);
@@ -97,6 +97,7 @@ mod test_helper {
         assert_eq!(str_to_num("0b101001").unwrap(), 0b101001);
         assert_eq!(str_to_num("0x12345").unwrap(), 0x12345);
         assert_eq!(str_to_num("0X1F2f345").unwrap(), 0x1f2f345);
+        assert_eq!(str_to_num("0").unwrap(), 0);
         assert!(str_to_num("0x12345123451234512").is_err());
     }
 

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -1,0 +1,59 @@
+/*
+ * helper.rs: Helper functions for implementing external or internal commands.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use core::*;
+use std::io::Write;
+use std::num;
+use yansi::Paint;
+
+pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
+    if n.len() >= 2 {
+        match &*n[0..2].to_lowercase() {
+            "0b" => return u64::from_str_radix(&n[2..], 2),
+            "0x" => return u64::from_str_radix(&n[2..], 16),
+            _ => (),
+        }
+    }
+    if n.chars().nth(0).unwrap() == '0' {
+        return u64::from_str_radix(&n[1..], 8);
+    }
+    return u64::from_str_radix(n, 10);
+}
+
+pub fn expect(core: &mut Core, args_len: u64, expect: u64) {
+    let (r, g, b) = core.color_palette[3];
+    let error = Paint::rgb(r, g, b, "Arguments Error").bold();
+    let expected = Paint::rgb(r, g, b, format!("{}", expect));
+    let found = Paint::rgb(r, g, b, format!("{}", args_len));
+    writeln!(core.stderr, "{}: Expected {} argument(s), found {}", error, expected, found).unwrap();
+}
+
+pub fn error_msg(core: &mut Core, title: &str, msg: &str) {
+    let (r, g, b) = core.color_palette[3];
+    writeln!(core.stderr, "{}: {}", Paint::rgb(r, g, b, "Error").bold(), Paint::rgb(r, g, b, title)).unwrap();
+    writeln!(core.stderr, "{}", msg).unwrap();
+}
+
+pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) {
+    let (r1, g1, b1) = core.color_palette[5];
+    let (r2, g2, b2) = core.color_palette[6];
+    writeln!(core.stdout, "Commands: [{} | {}]\n", Paint::rgb(r1, g1, b1, long), Paint::rgb(r1, g1, b1, short)).unwrap();
+    writeln!(core.stdout, "Usage:").unwrap();
+    for (args, description) in usage {
+        writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, short), Paint::rgb(r2, g2, b2, args), description,).unwrap()
+    }
+}

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -21,9 +21,9 @@ use std::fmt;
 use std::fmt::Display;
 use std::io::Write;
 use std::num;
+use std::process::exit;
 use std::rc::Rc;
 use yansi::Paint;
-use std::process::exit;
 
 pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     if n.len() >= 2 {
@@ -53,10 +53,10 @@ pub fn error_msg(core: &mut Core, title: &str, msg: &str) {
     writeln!(core.stderr, "{}", msg).unwrap();
 }
 
-pub fn panic_msg(core: &mut Core, title: &str, msg: &str) -> !{
+pub fn panic_msg(core: &mut Core, title: &str, msg: &str) -> ! {
     let (r, g, b) = core.color_palette[3];
     writeln!(core.stderr, "{}: {}", Paint::rgb(r, g, b, "Unrecoverable Error").bold(), Paint::rgb(r, g, b, title)).unwrap();
-    if !msg.is_empty(){
+    if !msg.is_empty() {
         writeln!(core.stderr, "{}", msg).unwrap();
     }
     writeln!(core.stderr, "{}", Paint::rgb(r, g, b, "Exiting!").bold()).unwrap();

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -25,6 +25,8 @@ use std::process::exit;
 use std::rc::Rc;
 use yansi::Paint;
 
+pub type MRc<T> = Rc<RefCell<T>>; //mutable refcounter
+
 pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     if n.len() >= 2 {
         match &*n[0..2].to_lowercase() {
@@ -92,7 +94,7 @@ pub trait Cmd {
     fn run(&mut self, &mut Core, &[String]);
     fn help(&self, &mut Core);
 }
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum AddrMode {
     Vir,
     Phy,

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -94,7 +94,7 @@ pub trait Cmd {
     fn run(&mut self, &mut Core, &[String]);
     fn help(&self, &mut Core);
 }
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AddrMode {
     Vir,
     Phy,

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -16,10 +16,12 @@
  */
 
 use core::*;
+use std::cell::{Ref, RefCell};
 use std::fmt;
 use std::fmt::Display;
 use std::io::Write;
 use std::num;
+use std::rc::Rc;
 use yansi::Paint;
 
 pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
@@ -82,6 +84,21 @@ impl Display for AddrMode {
             AddrMode::Phy => write!(f, "Phy"),
             AddrMode::Vir => write!(f, "Vir"),
         }
+    }
+}
+
+// Thanks to @stephaneyfx#2922 for the struct
+pub struct ReadOnly<T>(Rc<RefCell<T>>);
+
+impl<T> ReadOnly<T> {
+    pub fn borrow(&self) -> Ref<'_, T> {
+        self.0.borrow()
+    }
+}
+
+impl<T> From<Rc<RefCell<T>>> for ReadOnly<T> {
+    fn from(x: Rc<RefCell<T>>) -> Self {
+        ReadOnly(x)
     }
 }
 

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -61,7 +61,7 @@ pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) 
 }
 
 pub struct CmdFunctions {
-    pub run: fn(&mut Core, &Vec<String>),
+    pub run: fn(&mut Core, &[String]),
     pub help: fn(&mut Core),
 }
 

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -53,10 +53,17 @@ pub fn error_msg(core: &mut Core, title: &str, msg: &str) {
 pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) {
     let (r1, g1, b1) = core.color_palette[5];
     let (r2, g2, b2) = core.color_palette[6];
-    writeln!(core.stdout, "Commands: [{} | {}]\n", Paint::rgb(r1, g1, b1, long), Paint::rgb(r1, g1, b1, short)).unwrap();
+    let used;
+    if short.is_empty() {
+        writeln!(core.stdout, "Command: [{}]\n", Paint::rgb(r1, g1, b1, long)).unwrap();
+        used = long;
+    } else {
+        writeln!(core.stdout, "Commands: [{} | {}]\n", Paint::rgb(r1, g1, b1, long), Paint::rgb(r1, g1, b1, short)).unwrap();
+        used = short;
+    }
     writeln!(core.stdout, "Usage:").unwrap();
     for (args, description) in usage {
-        writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, short), Paint::rgb(r2, g2, b2, args), description,).unwrap()
+        writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, used), Paint::rgb(r2, g2, b2, args), description,).unwrap()
     }
 }
 
@@ -112,12 +119,20 @@ mod test_helper {
         assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Error Title\nSomething might have failed.\n");
     }
     #[test]
-    fn test_help() {
+    fn test_help_short() {
         let mut core = Core::new();
         core.stdout = Writer::new_buf();
         Paint::disable();
         help(&mut core, "Test", "t", vec![("t1", "test 1"), ("t2", "test 2")]);
         assert_eq!(core.stdout.utf8_string().unwrap(), "Commands: [Test | t]\n\nUsage:\nt t1\ttest 1\nt t2\ttest 2\n");
+    }
+    #[test]
+    fn test_help_long() {
+        let mut core = Core::new();
+        core.stdout = Writer::new_buf();
+        Paint::disable();
+        help(&mut core, "Test", "", vec![("t1", "test 1"), ("t2", "test 2")]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "Command: [Test]\n\nUsage:\nTest t1\ttest 1\nTest t2\ttest 2\n");
     }
     #[test]
     fn test_addr_mode() {

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -32,7 +32,7 @@ pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
             _ => (),
         }
     }
-    if n.chars().nth(0).unwrap() == '0' && n.len() > 1 {
+    if n.len() > 1 && n.chars().nth(0).unwrap() == '0' {
         return u64::from_str_radix(&n[1..], 8);
     }
     return u64::from_str_radix(n, 10);
@@ -77,7 +77,7 @@ pub trait Cmd {
     fn run(&mut self, &mut Core, &[String]);
     fn help(&self, &mut Core);
 }
-
+#[derive(Copy, Clone)]
 pub enum AddrMode {
     Vir,
     Phy,

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -16,6 +16,8 @@
  */
 
 use core::*;
+use std::fmt;
+use std::fmt::Display;
 use std::io::Write;
 use std::num;
 use yansi::Paint;
@@ -55,5 +57,23 @@ pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) 
     writeln!(core.stdout, "Usage:").unwrap();
     for (args, description) in usage {
         writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, short), Paint::rgb(r2, g2, b2, args), description,).unwrap()
+    }
+}
+
+pub struct CmdFunctions {
+    pub run: fn(&mut Core, &Vec<String>),
+    pub help: fn(&mut Core),
+}
+
+pub enum AddrMode {
+    Vir,
+    Phy,
+}
+impl Display for AddrMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AddrMode::Phy => write!(f, "Phy"),
+            AddrMode::Vir => write!(f, "Vir"),
+        }
     }
 }

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -53,14 +53,13 @@ pub fn error_msg(core: &mut Core, title: &str, msg: &str) {
 pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) {
     let (r1, g1, b1) = core.color_palette[5];
     let (r2, g2, b2) = core.color_palette[6];
-    let used;
-    if short.is_empty() {
+    let used = if short.is_empty() {
         writeln!(core.stdout, "Command: [{}]\n", Paint::rgb(r1, g1, b1, long)).unwrap();
-        used = long;
+        long
     } else {
         writeln!(core.stdout, "Commands: [{} | {}]\n", Paint::rgb(r1, g1, b1, long), Paint::rgb(r1, g1, b1, short)).unwrap();
-        used = short;
-    }
+        short
+    };
     writeln!(core.stdout, "Usage:").unwrap();
     for (args, description) in usage {
         writeln!(core.stdout, "{} {}\t{}", Paint::rgb(r1, g1, b1, used), Paint::rgb(r2, g2, b2, args), description,).unwrap()

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -23,6 +23,7 @@ use std::io::Write;
 use std::num;
 use std::rc::Rc;
 use yansi::Paint;
+use std::process::exit;
 
 pub fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     if n.len() >= 2 {
@@ -50,6 +51,16 @@ pub fn error_msg(core: &mut Core, title: &str, msg: &str) {
     let (r, g, b) = core.color_palette[3];
     writeln!(core.stderr, "{}: {}", Paint::rgb(r, g, b, "Error").bold(), Paint::rgb(r, g, b, title)).unwrap();
     writeln!(core.stderr, "{}", msg).unwrap();
+}
+
+pub fn panic_msg(core: &mut Core, title: &str, msg: &str) -> !{
+    let (r, g, b) = core.color_palette[3];
+    writeln!(core.stderr, "{}: {}", Paint::rgb(r, g, b, "Unrecoverable Error").bold(), Paint::rgb(r, g, b, title)).unwrap();
+    if !msg.is_empty(){
+        writeln!(core.stderr, "{}", msg).unwrap();
+    }
+    writeln!(core.stderr, "{}", Paint::rgb(r, g, b, "Exiting!").bold()).unwrap();
+    exit(-1);
 }
 
 pub fn help(core: &mut Core, long: &str, short: &str, usage: Vec<(&str, &str)>) {

--- a/rcore/src/helper.rs
+++ b/rcore/src/helper.rs
@@ -73,6 +73,11 @@ pub struct CmdFunctions {
     pub help: fn(&mut Core),
 }
 
+pub trait Cmd {
+    fn run(&mut self, &mut Core, &[String]);
+    fn help(&self, &mut Core);
+}
+
 pub enum AddrMode {
     Vir,
     Phy,

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -154,6 +154,51 @@ impl Cmd for ListMap {
         }
     }
     fn help(&self, core: &mut Core) {
-        help(core, &"maps", &"", vec![("", "List all memory maps")]);
+        help(core, &"maps", &"", vec![("", "List all memory maps.")]);
+    }
+}
+#[cfg(test)]
+mod test_mapping {
+    use super::*;
+    use writer::Writer;
+    use yansi::Paint;
+    #[test]
+    fn test_map_docs() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let map = Map::new();
+        map.help(&mut core);
+        assert_eq!(
+            core.stdout.utf8_string().unwrap(),
+            "Command: [map]\n\nUsage:\nmap [phy] [vir] [size]\tMap region from physical address space to virtual address space.\n"
+        );
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+    #[test]
+    fn test_unmap_docs() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let unmap = UnMap::new();
+        unmap.help(&mut core);
+        assert_eq!(
+            core.stdout.utf8_string().unwrap(),
+            "Commands: [unmap | um]\n\nUsage:\num [vir] [size]\tUnmap a previosly mapped memory region.\n"
+        );
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+    #[test]
+    fn test_list_map_docs() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let maps = ListMap::new();
+        maps.help(&mut core);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "Command: [maps]\n\nUsage:\nmaps\tList all memory maps.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
     }
 }

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -59,6 +59,9 @@ impl Cmd for Map {
             Ok(s) => s,
             Err(e) => return map_error(core, "size", &e.to_string()),
         };
+        if size == 0 {
+            return;
+        }
         if let Err(e) = core.io.map(phy, vir, size) {
             error_msg(core, "Failed to map memory", &e.to_string());
         }
@@ -92,6 +95,9 @@ impl Cmd for UnMap {
             Ok(s) => s,
             Err(e) => return unmap_error(core, "size", &e.to_string()),
         };
+        if size == 0 {
+            return;
+        }
         if let Err(e) = core.io.unmap(vir, size) {
             error_msg(core, "Failed to unmap memory", &e.to_string());
         }
@@ -192,6 +198,7 @@ mod test_mapping {
         map.run(&mut core, &["0x0".to_string(), "0x500".to_string(), "0x20".to_string()]);
         map.run(&mut core, &["0x10".to_string(), "0x520".to_string(), "0x20".to_string()]);
         map.run(&mut core, &["0x20".to_string(), "0x540".to_string(), "0x20".to_string()]);
+        map.run(&mut core, &["0x20".to_string(), "0x540".to_string(), "0".to_string()]);
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
         assert_eq!(core.stderr.utf8_string().unwrap(), "");
         core.stderr = Writer::new_buf();
@@ -209,6 +216,7 @@ mod test_mapping {
         core.stdout = Writer::new_buf();
         unmap.run(&mut core, &["0x520".to_string(), "0x20".to_string()]);
         unmap.run(&mut core, &["0x510".to_string(), "0x5".to_string()]);
+        unmap.run(&mut core, &["0x510".to_string(), "0".to_string()]);
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
         assert_eq!(core.stderr.utf8_string().unwrap(), "");
         core.stderr = Writer::new_buf();

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -73,7 +73,7 @@ fn unmap_help(core: &mut Core) {
 }
 
 fn unmap_run(core: &mut Core, args: &[String]) {
-        if args.len() != 2 {
+    if args.len() != 2 {
         expect(core, args.len() as u64, 2);
         return;
     }

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -24,7 +24,7 @@ use yansi::Paint;
 pub struct Map {}
 
 impl Map {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         Default::default()
     }
 }
@@ -78,7 +78,7 @@ impl Cmd for Map {
 pub struct UnMap {}
 
 impl UnMap {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         Default::default()
     }
 }
@@ -122,7 +122,7 @@ impl Cmd for UnMap {
 pub struct ListMap {}
 
 impl ListMap {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         Default::default()
     }
 }

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -108,7 +108,7 @@ fn lm_help(core: &mut Core) {
 }
 
 fn lm_run(core: &mut Core, args: &[String]) {
-    if args.len() != 0 {
+    if !args.is_empty() {
         expect(core, args.len() as u64, 0);
         return;
     }

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -20,115 +20,140 @@ use helper::*;
 use std::io::Write;
 use yansi::Paint;
 
-pub static MAPFUNCTION: CmdFunctions = CmdFunctions { run: map_run, help: map_help };
+#[derive(Default)]
+pub struct Map {}
 
-fn map_help(core: &mut Core) {
-    help(core, &"map", &"", vec![("[phy] [vir] [size]", "Map region from physical address space to virtual address space.")]);
-}
-
-fn map_run(core: &mut Core, args: &[String]) {
-    if args.len() != 3 {
-        expect(core, args.len() as u64, 3);
-        return;
-    }
-    let phy;
-    let vir;
-    let size;
-    match str_to_num(&args[0]) {
-        Ok(p) => phy = p,
-        Err(e) => {
-            let name = Paint::default("phy").bold();
-            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
-            error_msg(core, "Failed to map memory", &msg);
-            return;
-        }
-    }
-    match str_to_num(&args[1]) {
-        Ok(v) => vir = v,
-        Err(e) => {
-            let name = Paint::default("vir").bold();
-            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
-            error_msg(core, "Failed to map memory", &msg);
-            return;
-        }
-    }
-    match str_to_num(&args[2]) {
-        Ok(s) => size = s,
-        Err(e) => {
-            let name = Paint::default("size").bold();
-            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
-            error_msg(core, "Failed to map memory", &msg);
-            return;
-        }
-    }
-    if let Err(e) = core.io.map(phy, vir, size) {
-        error_msg(core, "Failed to map memory", &e.to_string());
+impl Map {
+    pub fn new() -> Self{
+        Default::default()
     }
 }
 
-pub static UNMAPFUNCTION: CmdFunctions = CmdFunctions { run: unmap_run, help: unmap_help };
-
-fn unmap_help(core: &mut Core) {
-    help(core, &"unmap", &"um", vec![("[vir] [size]", "Unmap a previosly mapped memory region.")]);
-}
-
-fn unmap_run(core: &mut Core, args: &[String]) {
-    if args.len() != 2 {
-        expect(core, args.len() as u64, 2);
-        return;
-    }
-    let vir;
-    let size;
-    match str_to_num(&args[0]) {
-        Ok(v) => vir = v,
-        Err(e) => {
-            let name = Paint::default("phy").bold();
-            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
-            error_msg(core, "Failed to unmap memory", &msg);
+impl Cmd for Map {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if args.len() != 3 {
+            expect(core, args.len() as u64, 3);
             return;
         }
-    }
-    match str_to_num(&args[1]) {
-        Ok(s) => size = s,
-        Err(e) => {
-            let name = Paint::default("vir").bold();
-            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
-            error_msg(core, "Failed to unmap memory", &msg);
-            return;
+        let phy;
+        let vir;
+        let size;
+        match str_to_num(&args[0]) {
+            Ok(p) => phy = p,
+            Err(e) => {
+                let name = Paint::default("phy").bold();
+                let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+                error_msg(core, "Failed to map memory", &msg);
+                return;
+            }
+        }
+        match str_to_num(&args[1]) {
+            Ok(v) => vir = v,
+            Err(e) => {
+                let name = Paint::default("vir").bold();
+                let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+                error_msg(core, "Failed to map memory", &msg);
+                return;
+            }
+        }
+        match str_to_num(&args[2]) {
+            Ok(s) => size = s,
+            Err(e) => {
+                let name = Paint::default("size").bold();
+                let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+                error_msg(core, "Failed to map memory", &msg);
+                return;
+            }
+        }
+        if let Err(e) = core.io.map(phy, vir, size) {
+            error_msg(core, "Failed to map memory", &e.to_string());
         }
     }
-    if let Err(e) = core.io.unmap(vir, size) {
-        error_msg(core, "Failed to unmap memory", &e.to_string());
+    fn help(&self, core: &mut Core) {
+        help(core, &"map", &"", vec![("[phy] [vir] [size]", "Map region from physical address space to virtual address space.")]);
     }
 }
-pub static LISTMAPFUNCTION: CmdFunctions = CmdFunctions { run: lm_run, help: lm_help };
 
-fn lm_help(core: &mut Core) {
-    help(core, &"maps", &"", vec![("", "List all memory maps")]);
+#[derive(Default)]
+pub struct UnMap {}
+
+impl UnMap {
+    pub fn new() -> Self{
+        Default::default()
+    }
 }
 
-fn lm_run(core: &mut Core, args: &[String]) {
-    if !args.is_empty() {
-        expect(core, args.len() as u64, 0);
-        return;
+impl Cmd for UnMap {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if args.len() != 2 {
+            expect(core, args.len() as u64, 2);
+            return;
+        }
+        let vir;
+        let size;
+        match str_to_num(&args[0]) {
+            Ok(v) => vir = v,
+            Err(e) => {
+                let name = Paint::default("phy").bold();
+                let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+                error_msg(core, "Failed to unmap memory", &msg);
+                return;
+            }
+        }
+        match str_to_num(&args[1]) {
+            Ok(s) => size = s,
+            Err(e) => {
+                let name = Paint::default("vir").bold();
+                let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+                error_msg(core, "Failed to unmap memory", &msg);
+                return;
+            }
+        }
+        if let Err(e) = core.io.unmap(vir, size) {
+            error_msg(core, "Failed to unmap memory", &e.to_string());
+        }
     }
-    let (r, g, b) = core.color_palette[5];
-    writeln!(
-        core.stdout,
-        "{: <20}{: <20}{: <5}",
-        Paint::rgb(r, g, b, "Virtual Address"),
-        Paint::rgb(r, g, b, "Physical Address"),
-        Paint::rgb(r, g, b, "Size")
-    )
-    .unwrap();
-    for map in core.io.map_iter() {
+    fn help(&self, core: &mut Core) {
+        help(core, &"unmap", &"um", vec![("[vir] [size]", "Unmap a previosly mapped memory region.")]);
+    }
+}
+
+#[derive(Default)]
+pub struct ListMap {}
+
+impl ListMap {
+    pub fn new() -> Self{
+        Default::default()
+    }
+}
+
+impl Cmd for ListMap {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if !args.is_empty() {
+            expect(core, args.len() as u64, 0);
+            return;
+        }
+        let (r, g, b) = core.color_palette[5];
         writeln!(
             core.stdout,
             "{: <20}{: <20}{: <5}",
-            format!("0x{:x}", map.vaddr),
-            format!("0x{:x}", map.paddr),
-            format!("0x{:x}", map.size)
+            Paint::rgb(r, g, b, "Virtual Address"),
+            Paint::rgb(r, g, b, "Physical Address"),
+            Paint::rgb(r, g, b, "Size")
         )
         .unwrap();
+        for map in core.io.map_iter() {
+            writeln!(
+                core.stdout,
+                "{: <20}{: <20}{: <5}",
+                format!("0x{:x}", map.vaddr),
+                format!("0x{:x}", map.paddr),
+                format!("0x{:x}", map.size)
+            )
+            .unwrap();
+        }
+    }
+    fn help(&self, core: &mut Core) {
+        help(core, &"maps", &"", vec![("", "List all memory maps")]);
     }
 }

--- a/rcore/src/io/map.rs
+++ b/rcore/src/io/map.rs
@@ -1,0 +1,134 @@
+/*
+ * map.rs: commands for mapping/unmapping memory regions and listing mapped regions as well.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use core::*;
+use helper::*;
+use std::io::Write;
+use yansi::Paint;
+
+pub static MAPFUNCTION: CmdFunctions = CmdFunctions { run: map_run, help: map_help };
+
+fn map_help(core: &mut Core) {
+    help(core, &"map", &"", vec![("[phy] [vir] [size]", "Map region from physical address space to virtual address space.")]);
+}
+
+fn map_run(core: &mut Core, args: &[String]) {
+    if args.len() != 3 {
+        expect(core, args.len() as u64, 3);
+        return;
+    }
+    let phy;
+    let vir;
+    let size;
+    match str_to_num(&args[0]) {
+        Ok(p) => phy = p,
+        Err(e) => {
+            let name = Paint::default("phy").bold();
+            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+            error_msg(core, "Failed to map memory", &msg);
+            return;
+        }
+    }
+    match str_to_num(&args[1]) {
+        Ok(v) => vir = v,
+        Err(e) => {
+            let name = Paint::default("vir").bold();
+            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+            error_msg(core, "Failed to map memory", &msg);
+            return;
+        }
+    }
+    match str_to_num(&args[2]) {
+        Ok(s) => size = s,
+        Err(e) => {
+            let name = Paint::default("size").bold();
+            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+            error_msg(core, "Failed to map memory", &msg);
+            return;
+        }
+    }
+    if let Err(e) = core.io.map(phy, vir, size) {
+        error_msg(core, "Failed to map memory", &e.to_string());
+    }
+}
+
+pub static UNMAPFUNCTION: CmdFunctions = CmdFunctions { run: unmap_run, help: unmap_help };
+
+fn unmap_help(core: &mut Core) {
+    help(core, &"unmap", &"um", vec![("[vir] [size]", "Unmap a previosly mapped memory region.")]);
+}
+
+fn unmap_run(core: &mut Core, args: &[String]) {
+        if args.len() != 2 {
+        expect(core, args.len() as u64, 2);
+        return;
+    }
+    let vir;
+    let size;
+    match str_to_num(&args[0]) {
+        Ok(v) => vir = v,
+        Err(e) => {
+            let name = Paint::default("phy").bold();
+            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+            error_msg(core, "Failed to unmap memory", &msg);
+            return;
+        }
+    }
+    match str_to_num(&args[1]) {
+        Ok(s) => size = s,
+        Err(e) => {
+            let name = Paint::default("vir").bold();
+            let msg = format!("Failed to parse {}, {}", name, &e.to_string());
+            error_msg(core, "Failed to unmap memory", &msg);
+            return;
+        }
+    }
+    if let Err(e) = core.io.unmap(vir, size) {
+        error_msg(core, "Failed to unmap memory", &e.to_string());
+    }
+}
+pub static LISTMAPFUNCTION: CmdFunctions = CmdFunctions { run: lm_run, help: lm_help };
+
+fn lm_help(core: &mut Core) {
+    help(core, &"maps", &"", vec![("", "List all memory maps")]);
+}
+
+fn lm_run(core: &mut Core, args: &[String]) {
+    if args.len() != 0 {
+        expect(core, args.len() as u64, 0);
+        return;
+    }
+    let (r, g, b) = core.color_palette[5];
+    writeln!(
+        core.stdout,
+        "{: <20}{: <20}{: <5}",
+        Paint::rgb(r, g, b, "Virtual Address"),
+        Paint::rgb(r, g, b, "Physical Address"),
+        Paint::rgb(r, g, b, "Size")
+    )
+    .unwrap();
+    for map in core.io.map_iter() {
+        writeln!(
+            core.stdout,
+            "{: <20}{: <20}{: <5}",
+            format!("0x{:x}", map.vaddr),
+            format!("0x{:x}", map.paddr),
+            format!("0x{:x}", map.size)
+        )
+        .unwrap();
+    }
+}

--- a/rcore/src/io/mod.rs
+++ b/rcore/src/io/mod.rs
@@ -19,12 +19,12 @@ mod print_hex;
 use self::map::*;
 use self::print_hex::*;
 use core::Core;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub fn register_io(core: &mut Core) {
-    core.add_command("map", Box::new(Map::new()));
-    core.add_command("maps", Box::new(ListMap::new()));
-    core.add_command("printHex", Box::new(PrintHex::new()));
-    core.add_command("px", Box::new(PrintHex::new()));
-    core.add_command("unmap", Box::new(UnMap::new()));
-    core.add_command("um", Box::new(UnMap::new()));
+    core.add_command("map", "", Rc::new(RefCell::new(Map::new())));
+    core.add_command("maps", "", Rc::new(RefCell::new(ListMap::new())));
+    core.add_command("printHex", "px", Rc::new(RefCell::new(PrintHex::new())));
+    core.add_command("unmap", "um", Rc::new(RefCell::new(UnMap::new())));
 }

--- a/rcore/src/io/mod.rs
+++ b/rcore/src/io/mod.rs
@@ -1,7 +1,5 @@
-#![warn(clippy::cargo)]
-#![allow(clippy::needless_return)]
 /*
- * rcore: rair core library
+ * io: commands handling IO.
  * Copyright (C) 2019  Oddcoder
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,15 +14,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-extern crate app_dirs;
-extern crate rio;
-extern crate rtrees;
-extern crate rustyline;
-extern crate yansi;
-mod core;
-mod helper;
-mod io;
-mod loc;
-pub use core::*;
-pub use helper::*;
-pub use io::*;
+mod print_hex;
+
+pub use self::print_hex::*;

--- a/rcore/src/io/mod.rs
+++ b/rcore/src/io/mod.rs
@@ -16,5 +16,15 @@
  */
 mod map;
 mod print_hex;
-pub use self::map::*;
-pub use self::print_hex::*;
+use self::map::*;
+use self::print_hex::*;
+use core::Core;
+
+pub fn register_io(core: &mut Core) {
+    core.add_command("map", Box::new(Map::new()));
+    core.add_command("maps", Box::new(ListMap::new()));
+    core.add_command("printHex", Box::new(PrintHex::new()));
+    core.add_command("px", Box::new(PrintHex::new()));
+    core.add_command("unmap", Box::new(UnMap::new()));
+    core.add_command("um", Box::new(UnMap::new()));
+}

--- a/rcore/src/io/mod.rs
+++ b/rcore/src/io/mod.rs
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+mod map;
 mod print_hex;
-
+pub use self::map::*;
 pub use self::print_hex::*;

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -27,7 +27,7 @@ fn px_help(core: &mut Core) {
     help(core, &"printHex", &"px", vec![("[size]", "View data of at current location in hex format")]);
 }
 
-fn px_run(core: &mut Core, args: &Vec<String>) {
+fn px_run(core: &mut Core, args: &[String]) {
     if args.len() != 1 {
         expect(core, args.len() as u64, 1);
         return;

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -26,7 +26,7 @@ use yansi::Paint;
 pub struct PrintHex {}
 
 impl PrintHex {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         Default::default()
     }
 }

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -47,7 +47,7 @@ fn px_run(core: &mut Core, args: &[String]) {
     let mut data = vec![0; size as usize];
     match core.mode {
         AddrMode::Phy => core.io.pread(core.get_loc(), &mut data).unwrap(),
-        AddrMode::Vir => core.io.pread(core.get_loc(), &mut data).unwrap(),
+        AddrMode::Vir => core.io.vread(core.get_loc(), &mut data).unwrap(),
     }
     let banner = core.color_palette[5];
     let na = core.color_palette[4];

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -19,6 +19,7 @@ use core::*;
 use helper::*;
 use std::cmp;
 use std::io::Write;
+use writer::*;
 use yansi::Paint;
 pub static PRINTHEXFUNCTION: CmdFunctions = CmdFunctions { run: px_run, help: px_help };
 

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -58,8 +58,8 @@ fn px_run(core: &mut Core, args: &Vec<String>) {
     .unwrap();
     for i in (0..size).step_by(16) {
         write!(core.stdout, "{} ", Paint::rgb(banner.0, banner.1, banner.2, format!("0x{:08x}", core.get_loc() + i))).unwrap();
-        let mut ascii = Writer::Bytes(Vec::new());
-        let mut hex = Writer::Bytes(Vec::new());
+        let mut ascii = Writer::new_buf();
+        let mut hex = Writer::new_buf();
         for j in i..cmp::min(i + 16, size) {
             let c = data[j as usize];
             match j % 2 {
@@ -73,10 +73,6 @@ fn px_run(core: &mut Core, args: &Vec<String>) {
                 write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, ".")).unwrap();
             }
         }
-        if let Writer::Bytes(bytes) = ascii {
-            if let Writer::Bytes(h) = hex {
-                writeln!(core.stdout, "{: <40} {}", String::from_utf8(h).unwrap(), String::from_utf8(bytes).unwrap()).unwrap();
-            }
-        }
+        writeln!(core.stdout, "{: <40} {}", hex.utf8_string().unwrap(), ascii.utf8_string().unwrap()).unwrap();
     }
 }

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -1,0 +1,82 @@
+/*
+ * print_hex: commands handling hex printing.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use core::*;
+use helper::*;
+use std::cmp;
+use std::io::Write;
+use yansi::Paint;
+pub static PRINTHEXFUNCTION: CmdFunctions = CmdFunctions { run: px_run, help: px_help };
+
+fn px_help(core: &mut Core) {
+    help(core, &"printHex", &"px", vec![("[size]", "View data of at current location in hex format")]);
+}
+
+fn px_run(core: &mut Core, args: &Vec<String>) {
+    if args.len() != 1 {
+        expect(core, args.len() as u64, 1);
+        return;
+    }
+    let size;
+    match str_to_num(&args[0]) {
+        Ok(s) => size = s,
+        Err(e) => {
+            error_msg(
+                core,
+                &e.to_string(),
+                &format!("Expect Hex, binary, Octal or Decimal value but found {} instead", Paint::default(&args[0]).italic()),
+            );
+            return;
+        }
+    }
+    let mut data = vec![0; size as usize];
+    match core.mode {
+        AddrMode::Phy => core.io.pread(core.get_loc(), &mut data).unwrap(),
+        AddrMode::Vir => core.io.pread(core.get_loc(), &mut data).unwrap(),
+    }
+    let banner = core.color_palette[5];
+    let na = core.color_palette[4];
+    writeln!(
+        core.stdout,
+        "{}",
+        Paint::rgb(banner.0, banner.1, banner.2, "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF")
+    )
+    .unwrap();
+    for i in (0..size).step_by(16) {
+        write!(core.stdout, "{} ", Paint::rgb(banner.0, banner.1, banner.2, format!("0x{:08x}", core.get_loc() + i))).unwrap();
+        let mut ascii = Writer::Bytes(Vec::new());
+        let mut hex = Writer::Bytes(Vec::new());
+        for j in i..cmp::min(i + 16, size) {
+            let c = data[j as usize];
+            match j % 2 {
+                0 => write!(hex, "{:02x}", c).unwrap(),
+                1 => write!(hex, "{:02x} ", c).unwrap(),
+                _ => (),
+            }
+            if c >= 0x21 && c <= 0x7E {
+                write!(ascii, "{}", c as char).unwrap()
+            } else {
+                write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, ".")).unwrap();
+            }
+        }
+        if let Writer::Bytes(bytes) = ascii {
+            if let Writer::Bytes(h) = hex {
+                writeln!(core.stdout, "{: <40} {}", String::from_utf8(h).unwrap(), String::from_utf8(bytes).unwrap()).unwrap();
+            }
+        }
+    }
+}

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -45,7 +45,7 @@ impl Cmd for PrintHex {
                 return error_msg(
                     core,
                     &e.to_string(),
-                    &format!("Expect Hex, binary, Octal or Decimal value but found {} instead", Paint::default(&args[0]).italic()),
+                    &format!("Expect Hex, binary, Octal or Decimal value but found {} instead.", Paint::default(&args[0]).italic()),
                 )
             }
         };
@@ -479,5 +479,23 @@ mod test_print_hex {
     #[test]
     fn test_px_vir() {
         operate_on_file(&test_px_vir_cb, DATA);
+    }
+
+    #[test]
+    fn test_px_err() {
+        Paint::disable();
+        let mut core = Core::new();
+        let mut px = PrintHex::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        px.run(&mut core, &[]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Arguments Error: Expected 1 argument(s), found 0.\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: cannot parse integer from empty string\nExpect Hex, binary, Octal or Decimal value but found 0x instead.\n");
     }
 }

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -33,35 +33,34 @@ impl PrintHex {
 
 impl Cmd for PrintHex {
     fn run(&mut self, core: &mut Core, args: &[String]) {
+        // we can always optimize by try and using pread an vread.
+        // If they fail, only then we might want to attempt the sparce version.
         if args.len() != 1 {
             expect(core, args.len() as u64, 1);
             return;
         }
-        let loc = core.get_loc();
-        let size;
-        match str_to_num(&args[0]) {
-            Ok(s) => size = s,
+        let size = match str_to_num(&args[0]) {
+            Ok(s) => s,
             Err(e) => {
-                error_msg(
+                return error_msg(
                     core,
                     &e.to_string(),
                     &format!("Expect Hex, binary, Octal or Decimal value but found {} instead", Paint::default(&args[0]).italic()),
-                );
-                return;
+                )
             }
+        };
+        if size == 0 {
+            return;
         }
+        let loc = core.get_loc();
         let data_or_no_data = match core.mode {
             AddrMode::Phy => core.io.pread_sparce(loc, size),
             AddrMode::Vir => core.io.vread_sparce(loc, size),
         };
-        let data;
-        match data_or_no_data {
-            Ok(d) => data = d,
-            Err(e) => {
-                error_msg(core, "Read Failed", &e.to_string());
-                return;
-            }
-        }
+        let data = match data_or_no_data {
+            Ok(d) => d,
+            Err(e) => return error_msg(core, "Read Failed", &e.to_string()),
+        };
         let banner = core.color_palette[5];
         let na = core.color_palette[4];
         writeln!(
@@ -88,17 +87,397 @@ impl Cmd for PrintHex {
                     }
                 } else {
                     if j % 2 == 0 {
-                        write!(hex, "**").unwrap();
+                        write!(hex, "##").unwrap();
                     } else {
-                        write!(hex, "** ").unwrap();
+                        write!(hex, "## ").unwrap();
                     }
-                    write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, "*")).unwrap();
+                    write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, "#")).unwrap();
                 }
             }
             writeln!(core.stdout, "{: <40} {}", hex.utf8_string().unwrap(), ascii.utf8_string().unwrap()).unwrap();
         }
     }
     fn help(&self, core: &mut Core) {
-        help(core, &"printHex", &"px", vec![("[size]", "View data of at current location in hex format")]);
+        help(core, &"printHex", &"px", vec![("[size]", "View data of at current location in hex format.")]);
+    }
+}
+
+#[cfg(test)]
+mod test_print_hex {
+    use super::*;
+    use rio::*;
+    use std::path::Path;
+    use test_file::*;
+    use writer::Writer;
+    use yansi::Paint;
+
+    #[test]
+    fn test_help() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let px = PrintHex::new();
+        px.help(&mut core);
+        assert_eq!(
+            core.stdout.utf8_string().unwrap(),
+            "Commands: [printHex | px]\n\nUsage:\npx [size]\tView data of at current location in hex format.\n"
+        );
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+    fn test_px_cb(path: &Path) {
+        Paint::disable();
+        let mut core = Core::new();
+        let mut px = PrintHex::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.io.open(&path.to_string_lossy(), IoMode::READ).unwrap();
+        px.run(&mut core, &["0x0".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+        0x00000000 00                                       .\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x2".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001                                     ..\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x3".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 01                                  ...\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x4".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102                                ....\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x5".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 03                             .....\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x6".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305                           ......\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x7".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 08                        .......\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x8".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+        0x00000000 0001 0102 0305 080d                      ........\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x9".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 15                   .........\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xa".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522                 .........\"\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xb".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 37              .........\"7\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xc".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759            .........\"7Y\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xd".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90         .........\"7Y.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xe".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9       .........\"7Y..\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0xf".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 79    .........\"7Y..y\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x10".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x11".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db                                       .\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x12".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d                                     .=\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x13".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 18                                  .=.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x14".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855                                .=.U\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x15".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6d                             .=.Um\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x16".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2                           .=.Um.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x17".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2f                        .=.Um./\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x18".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1                      .=.Um./.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x19".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 20                   .=.Um./..\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1a".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011                 .=.Um./...\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1b".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 31              .=.Um./...1\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1c".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142            .=.Um./...1B\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1d".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73         .=.Um./...1Bs\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        
+        px.run(&mut core, &["0x1e".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5       .=.Um./...1Bs.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x1f".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5 28    .=.Um./...1Bs.(\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x20".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5 28dd  .=.Um./...1Bs.(.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x21".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5 28dd  .=.Um./...1Bs.(.\n\
+         0x00000020 05                                       .\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x22".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5 28dd  .=.Um./...1Bs.(.\n\
+         0x00000020 05e2                                     ..\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        px.run(&mut core, &["0x23".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000000 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000010 db3d 1855 6dc2 2ff1 2011 3142 73b5 28dd  .=.Um./...1Bs.(.\n\
+         0x00000020 05e2 e7                                  ...\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_px() {
+        operate_on_file(&test_px_cb, DATA);
+    }
+
+    fn test_px_vir_cb(path: &Path) {
+        Paint::disable();
+        let mut core = Core::new();
+        let mut px = PrintHex::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.io.open(&path.to_string_lossy(), IoMode::READ).unwrap();
+        px.run(&mut core, &["0x0".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.mode = AddrMode::Vir;
+        core.io.map(0x0, 0x500, 0x10).unwrap();
+        core.io.map(0x15, 0x515, 0x5).unwrap();
+        core.io.map(0x10, 0x520, 0x20).unwrap();
+        core.io.map(0x20, 0x540, 0x20).unwrap();
+        core.set_loc(0x500);
+        px.run(&mut core, &["0x65".to_string()]);
+        assert_eq!(core.stdout.utf8_string().unwrap(), 
+        "- offset -  0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF\n\
+         0x00000500 0001 0102 0305 080d 1522 3759 90e9 7962  .........\"7Y..yb\n\
+         0x00000510 #### #### ##c2 2ff1 2011 #### #### ####  #####./...######\n\
+         0x00000520 db3d 1855 6dc2 2ff1 2011 3142 73b5 28dd  .=.Um./...1Bs.(.\n\
+         0x00000530 05e2 e7c9 b079 29a2 cb6d 38a5 dd82 5fe1  .....y)..m8..._.\n\
+         0x00000540 05e2 e7c9 b079 29a2 cb6d 38a5 dd82 5fe1  .....y)..m8..._.\n\
+         0x00000550 4021 6182 e365 48ad f5a2 9739 d009 d9e2  @!a..eH....9....\n\
+         0x00000560 #### #### ##                             #####\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+
+    }
+
+    #[test]
+    fn test_px_vir() {
+        operate_on_file(&test_px_vir_cb, DATA);
     }
 }

--- a/rcore/src/io/print_hex.rs
+++ b/rcore/src/io/print_hex.rs
@@ -75,27 +75,24 @@ impl Cmd for PrintHex {
             let mut ascii = Writer::new_buf();
             let mut hex = Writer::new_buf();
             for j in i..cmp::min(i + 16, size) {
-                match data.get(&(j + loc)) {
-                    Some(c) => {
-                        match j % 2 {
-                            0 => write!(hex, "{:02x}", c).unwrap(),
-                            1 => write!(hex, "{:02x} ", c).unwrap(),
-                            _ => (),
-                        }
-                        if *c >= 0x21 && *c <= 0x7E {
-                            write!(ascii, "{}", *c as char).unwrap()
-                        } else {
-                            write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, ".")).unwrap();
-                        }
+                if let Some(c) = data.get(&(j + loc)) {
+                    if j % 2 == 0 {
+                        write!(hex, "{:02x}", c).unwrap();
+                    } else {
+                        write!(hex, "{:02x} ", c).unwrap();
                     }
-                    None => {
-                        match j % 2 {
-                            0 => write!(hex, "**").unwrap(),
-                            1 => write!(hex, "** ").unwrap(),
-                            _ => (),
-                        }
-                        write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, "*")).unwrap();
+                    if *c >= 0x21 && *c <= 0x7E {
+                        write!(ascii, "{}", *c as char).unwrap()
+                    } else {
+                        write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, ".")).unwrap();
                     }
+                } else {
+                    if j % 2 == 0 {
+                        write!(hex, "**").unwrap();
+                    } else {
+                        write!(hex, "** ").unwrap();
+                    }
+                    write!(ascii, "{}", Paint::rgb(na.0, na.1, na.2, "*")).unwrap();
                 }
             }
             writeln!(core.stdout, "{: <40} {}", hex.utf8_string().unwrap(), ascii.utf8_string().unwrap()).unwrap();

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -1,0 +1,25 @@
+#![warn(clippy::cargo)]
+#![allow(clippy::needless_return)]
+/*
+ * rcore: rair core library
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+extern crate app_dirs;
+extern crate rio;
+extern crate rtrees;
+extern crate rustyline;
+
+mod core;
+pub use core::*;

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -18,15 +18,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 extern crate app_dirs;
+extern crate rcmd;
 extern crate rio;
 extern crate rtrees;
 extern crate rustyline;
+extern crate rustyline_derive;
 extern crate yansi;
+mod commands;
 mod core;
 mod helper;
 mod io;
+mod lineformatter;
 mod loc;
 mod writer;
+
 pub use core::*;
 pub use helper::*;
 pub use io::*;

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -24,6 +24,8 @@ extern crate rtrees;
 extern crate rustyline;
 extern crate rustyline_derive;
 extern crate yansi;
+
+#[cfg(test)] extern crate test_file;
 mod commands;
 mod core;
 mod helper;

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
 /*
  * rcore: rair core library

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -25,7 +25,8 @@ extern crate rustyline;
 extern crate rustyline_derive;
 extern crate yansi;
 
-#[cfg(test)] extern crate test_file;
+#[cfg(test)]
+extern crate test_file;
 mod commands;
 mod core;
 mod helper;

--- a/rcore/src/lib.rs
+++ b/rcore/src/lib.rs
@@ -25,6 +25,8 @@ mod core;
 mod helper;
 mod io;
 mod loc;
+mod writer;
 pub use core::*;
 pub use helper::*;
 pub use io::*;
+pub use writer::*;

--- a/rcore/src/lineformatter.rs
+++ b/rcore/src/lineformatter.rs
@@ -1,0 +1,114 @@
+/*
+ * lineformatter.rs: Autocompletion / hinting / colorzing input.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use commands::Commands;
+use helper::ReadOnly;
+use rcmd::*;
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::Context;
+use rustyline_derive::Helper;
+use std::borrow::Cow::{self, Owned};
+use std::cell::RefCell;
+use std::rc::Rc;
+use yansi::Paint;
+
+#[derive(Helper)]
+pub struct LineFormatter {
+    hinter: HistoryHinter,
+    commands: ReadOnly<Commands>,
+}
+
+impl LineFormatter {
+    pub fn new(commands: Rc<RefCell<Commands>>) -> Self {
+        LineFormatter {
+            hinter: HistoryHinter {},
+            commands: commands.into(),
+        }
+    }
+    fn tree_complete(&self, tree: ParseTree) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        match tree {
+            // If we have a help then we just return
+            // all the commands sharing same prefix ending with the help token
+            ParseTree::Help(help) => {
+                let mut ret = Vec::new();
+                for suggestion in self.commands.borrow().prefix(&help.command) {
+                    let display = (*suggestion).to_string();
+                    let replacement = (*suggestion).to_string() + "?";
+                    ret.push(Pair { display, replacement });
+                }
+                return Ok((0, ret));
+            }
+            // if it is command
+            // first if we are taking arguments no autocomplate else autocomplete normally ;)
+            ParseTree::Cmd(cmd) => {
+                if !cmd.args.is_empty() {
+                    return Ok((0, Vec::new()));
+                }
+                let mut ret = Vec::new();
+                for suggestion in self.commands.borrow().prefix(&cmd.command) {
+                    let display = (*suggestion).to_string();
+                    let replacement = (*suggestion).to_string();
+                    ret.push(Pair { display, replacement });
+                }
+                return Ok((0, ret));
+            }
+            _ => return Ok((0, Vec::new())),
+        }
+    }
+}
+
+impl Completer for LineFormatter {
+    type Candidate = Pair;
+
+    fn complete(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        // first figure which token are we completing
+        // we will do so by starting at line[pos] and keep incrementing till:
+        //  A- we get to see a white space
+        //  B- we reach end of text.
+        let mut p = pos;
+        while p < line.len() {
+            let c: Option<char> = line.chars().nth(p);
+            if let Some(character) = c {
+                if character.is_whitespace() {
+                    break;
+                }
+            }
+            p += 1;
+        }
+        // next we parse the line
+        let t = ParseTree::construct(&line[0..p]);
+        match t {
+            Err(_) => return Ok((0, Vec::new())),
+            Ok(tree) => return self.tree_complete(tree),
+        }
+    }
+}
+
+impl Hinter for LineFormatter {
+    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
+        self.hinter.hint(line, pos, ctx)
+    }
+}
+
+impl Highlighter for LineFormatter {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned(format!("{}", Paint::default(hint).bold().italic().dimmed()))
+    }
+}

--- a/rcore/src/loc/history.rs
+++ b/rcore/src/loc/history.rs
@@ -42,3 +42,45 @@ impl History {
         self.back.push((core.mode, core.get_loc()));
     }
 }
+
+#[cfg(test)]
+mod test_history {
+    use super::*;
+    #[test]
+    fn test_history() {
+        let mut history = History::new();
+        let mut core = Core::new();
+        assert_eq!(history.backward(&core), None);
+        assert_eq!(history.backward(&core), None);
+        history.add(&core);
+        core.set_loc(0x50);
+        history.add(&core);
+        core.set_loc(0x100);
+        core.mode = AddrMode::Vir;
+        history.add(&core);
+        core.set_loc(0x150);
+        core.mode = AddrMode::Phy;
+        history.add(&core);
+        assert_eq!(history.backward(&core).unwrap(), (AddrMode::Phy, 0x150));
+        core.set_loc(0x150);
+        assert_eq!(history.backward(&core).unwrap(), (AddrMode::Vir, 0x100));
+        core.set_loc(0x100);
+        core.mode = AddrMode::Vir;
+        assert_eq!(history.backward(&core).unwrap(), (AddrMode::Phy, 0x50));
+        core.set_loc(0x50);
+        core.mode = AddrMode::Phy;
+        assert_eq!(history.forward(&core).unwrap(), (AddrMode::Vir, 0x100));
+        core.set_loc(0x100);
+        core.mode = AddrMode::Vir;
+        assert_eq!(history.backward(&core).unwrap(), (AddrMode::Phy, 0x50));
+        core.set_loc(0x50);
+        core.mode = AddrMode::Phy;
+        assert_eq!(history.backward(&core).unwrap(), (AddrMode::Phy, 0x0));
+        core.set_loc(0x0);
+        core.mode = AddrMode::Phy;
+        assert_eq!(history.backward(&core), None);
+        assert_eq!(history.forward(&core).unwrap(), (AddrMode::Phy, 0x50));
+        assert_eq!(history.forward(&core).unwrap(), (AddrMode::Vir, 0x100));
+        assert_eq!(history.forward(&core).unwrap(), (AddrMode::Phy, 0x150));
+    }
+}

--- a/rcore/src/loc/history.rs
+++ b/rcore/src/loc/history.rs
@@ -1,0 +1,44 @@
+/*
+ * history.rs: history managment for seek and mode.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use core::Core;
+use helper::AddrMode;
+#[derive(Default)]
+pub struct History {
+    back: Vec<(AddrMode, u64)>,
+    front: Vec<(AddrMode, u64)>,
+}
+
+impl History {
+    pub fn new() -> Self {
+        return Default::default();
+    }
+    pub fn backward(&mut self, core: &Core) -> Option<(AddrMode, u64)> {
+        let (mode, addr) = self.back.pop()?;
+        self.front.push((core.mode, core.get_loc()));
+        return Some((mode, addr));
+    }
+    pub fn forward(&mut self, core: &Core) -> Option<(AddrMode, u64)> {
+        let (mode, addr) = self.front.pop()?;
+        self.back.push((core.mode, core.get_loc()));
+        return Some((mode, addr));
+    }
+    pub fn add(&mut self, core: &Core) {
+        self.front.clear();
+        self.back.push((core.mode, core.get_loc()));
+    }
+}

--- a/rcore/src/loc/mod.rs
+++ b/rcore/src/loc/mod.rs
@@ -19,10 +19,10 @@ mod seek;
 use self::mode::*;
 use self::seek::*;
 use core::Core;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub fn register_loc(core: &mut Core) {
-    core.add_command("mode", Box::new(Mode::new()));
-    core.add_command("m", Box::new(Mode::new()));
-    core.add_command("seek", Box::new(Seek::new()));
-    core.add_command("s", Box::new(Seek::new()));
+    core.add_command("mode", "m", Rc::new(RefCell::new(Mode::new())));
+    core.add_command("seek", "s", Rc::new(RefCell::new(Seek::new())));
 }

--- a/rcore/src/loc/mod.rs
+++ b/rcore/src/loc/mod.rs
@@ -1,7 +1,5 @@
-#![warn(clippy::cargo)]
-#![allow(clippy::needless_return)]
 /*
- * rcore: rair core library
+ * loc: commands handling file location.
  * Copyright (C) 2019  Oddcoder
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -16,11 +14,5 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-extern crate app_dirs;
-extern crate rio;
-extern crate rtrees;
-extern crate rustyline;
-
-mod core;
-mod loc;
-pub use core::*;
+mod seek;
+pub use self::seek::*;

--- a/rcore/src/loc/mod.rs
+++ b/rcore/src/loc/mod.rs
@@ -14,5 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+mod mode;
 mod seek;
+pub use self::mode::*;
 pub use self::seek::*;

--- a/rcore/src/loc/mod.rs
+++ b/rcore/src/loc/mod.rs
@@ -14,15 +14,17 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+mod history;
 mod mode;
 mod seek;
+use self::history::History;
 use self::mode::*;
 use self::seek::*;
 use core::Core;
 use std::cell::RefCell;
 use std::rc::Rc;
-
 pub fn register_loc(core: &mut Core) {
-    core.add_command("mode", "m", Rc::new(RefCell::new(Mode::new())));
-    core.add_command("seek", "s", Rc::new(RefCell::new(Seek::new())));
+    let history = Rc::new(RefCell::new(History::new()));
+    core.add_command("mode", "m", Rc::new(RefCell::new(Mode::with_history(history.clone()))));
+    core.add_command("seek", "s", Rc::new(RefCell::new(Seek::with_history(history))));
 }

--- a/rcore/src/loc/mod.rs
+++ b/rcore/src/loc/mod.rs
@@ -16,5 +16,13 @@
  */
 mod mode;
 mod seek;
-pub use self::mode::*;
-pub use self::seek::*;
+use self::mode::*;
+use self::seek::*;
+use core::Core;
+
+pub fn register_loc(core: &mut Core) {
+    core.add_command("mode", Box::new(Mode::new()));
+    core.add_command("m", Box::new(Mode::new()));
+    core.add_command("seek", Box::new(Seek::new()));
+    core.add_command("s", Box::new(Seek::new()));
+}

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -14,16 +14,22 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+use super::history::History;
 use core::*;
 use helper::*;
 use yansi::Paint;
 
 #[derive(Default)]
-pub struct Mode {}
+pub struct Mode {
+    history: MRc<History>,
+}
 
 impl Mode {
     pub fn new() -> Self {
         Default::default()
+    }
+    pub(super) fn with_history(history: MRc<History>) -> Self {
+        Mode { history }
     }
 }
 
@@ -34,8 +40,14 @@ impl Cmd for Mode {
             return;
         }
         match &*args[0] {
-            "vir" => core.mode = AddrMode::Vir,
-            "phy" => core.mode = AddrMode::Phy,
+            "vir" => {
+                self.history.borrow_mut().add(core);
+                core.mode = AddrMode::Vir;
+            }
+            "phy" => {
+                self.history.borrow_mut().add(core);
+                core.mode = AddrMode::Phy
+            }
             _ => {
                 let msg = format!(
                     "Expected {} or {}, but found {}",

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -41,7 +41,7 @@ impl Cmd for Mode {
                 self.history.borrow_mut().add(core);
                 if core.mode == AddrMode::Phy {
                     let vir = core.io.phy_to_vir(core.get_loc());
-                    if !vir.is_empty(){
+                    if !vir.is_empty() {
                         core.set_loc(vir[0]);
                     }
                 }
@@ -72,7 +72,37 @@ impl Cmd for Mode {
             core,
             &"mode",
             &"m",
-            vec![("vir", "Set view mode to virtual address space."), ("phy", "Set view mode to phyisical address space.")],
+            vec![("vir", "Set view mode to virtual address space."), ("phy", "Set view mode to physical address space.")],
         );
     }
+}
+
+#[cfg(test)]
+mod test_mode {
+    use super::*;
+    use writer::Writer;
+    use yansi::Paint;
+
+    #[test]
+    fn test_docs() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let mode: Mode = Default::default();
+        mode.help(&mut core);
+        assert_eq!(
+            core.stdout.utf8_string().unwrap(),
+            "Commands: [mode | m]\n\
+             \n\
+             Usage:\n\
+             m vir\tSet view mode to virtual address space.\n\
+             m phy\tSet view mode to physical address space.\n\
+             "
+        );
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+
+    #[test]
+    fn test_mode() {}
 }

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -80,11 +80,11 @@ impl Cmd for Mode {
 #[cfg(test)]
 mod test_mode {
     use super::*;
+    use rio::*;
+    use std::path::Path;
+    use test_file::*;
     use writer::Writer;
     use yansi::Paint;
-    use test_file::*;
-    use std::path::Path;
-    use rio::*;
 
     #[test]
     fn test_docs() {
@@ -127,8 +127,6 @@ mod test_mode {
         mode.run(&mut core, &["phy".to_string()]);
         assert_eq!(core.get_loc(), len + 10);
         assert_eq!(core.mode, AddrMode::Phy);
-        
-        
     }
     #[test]
     fn test_mode() {
@@ -151,6 +149,5 @@ mod test_mode {
         mode.run(&mut core, &["not_real_arg".to_string()]);
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
         assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Invalid Mode\nExpected vir or phy, but found not_real_arg.\n");
-
     }
 }

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -25,9 +25,6 @@ pub struct Mode {
 }
 
 impl Mode {
-    pub fn new() -> Self {
-        Default::default()
-    }
     pub(super) fn with_history(history: MRc<History>) -> Self {
         Mode { history }
     }
@@ -42,10 +39,21 @@ impl Cmd for Mode {
         match &*args[0] {
             "vir" => {
                 self.history.borrow_mut().add(core);
+                if core.mode == AddrMode::Phy {
+                    let vir = core.io.phy_to_vir(core.get_loc());
+                    if !vir.is_empty(){
+                        core.set_loc(vir[0]);
+                    }
+                }
                 core.mode = AddrMode::Vir;
             }
             "phy" => {
                 self.history.borrow_mut().add(core);
+                if core.mode == AddrMode::Vir {
+                    if let Some(vir) = core.io.vir_to_phy(core.get_loc(), 1) {
+                        core.set_loc(vir[0].paddr);
+                    }
+                }
                 core.mode = AddrMode::Phy
             }
             _ => {

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -36,35 +36,31 @@ impl Cmd for Mode {
             expect(core, args.len() as u64, 1);
             return;
         }
-        match &*args[0] {
-            "vir" => {
-                self.history.borrow_mut().add(core);
-                if core.mode == AddrMode::Phy {
-                    let vir = core.io.phy_to_vir(core.get_loc());
-                    if !vir.is_empty() {
-                        core.set_loc(vir[0]);
-                    }
+        if args[0] == "vir" {
+            self.history.borrow_mut().add(core);
+            if core.mode == AddrMode::Phy {
+                let vir = core.io.phy_to_vir(core.get_loc());
+                if !vir.is_empty() {
+                    core.set_loc(vir[0]);
                 }
-                core.mode = AddrMode::Vir;
             }
-            "phy" => {
-                self.history.borrow_mut().add(core);
-                if core.mode == AddrMode::Vir {
-                    if let Some(vir) = core.io.vir_to_phy(core.get_loc(), 1) {
-                        core.set_loc(vir[0].paddr);
-                    }
+            core.mode = AddrMode::Vir;
+        } else if args[0] == "phy" {
+            self.history.borrow_mut().add(core);
+            if core.mode == AddrMode::Vir {
+                if let Some(vir) = core.io.vir_to_phy(core.get_loc(), 1) {
+                    core.set_loc(vir[0].paddr);
                 }
-                core.mode = AddrMode::Phy
             }
-            _ => {
-                let msg = format!(
-                    "Expected {} or {}, but found {}.",
-                    Paint::default("vir").italic().bold(),
-                    Paint::default("phy").italic().bold(),
-                    Paint::default(&args[0]).italic().bold(),
-                );
-                error_msg(core, "Invalid Mode", &msg);
-            }
+            core.mode = AddrMode::Phy
+        } else {
+            let msg = format!(
+                "Expected {} or {}, but found {}.",
+                Paint::default("vir").italic().bold(),
+                Paint::default("phy").italic().bold(),
+                Paint::default(&args[0]).italic().bold(),
+            );
+            error_msg(core, "Invalid Mode", &msg);
         }
     }
     fn help(&self, core: &mut Core) {

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -28,7 +28,7 @@ fn mode_help(core: &mut Core) {
     );
 }
 
-fn mode_run(core: &mut Core, args: &Vec<String>) {
+fn mode_run(core: &mut Core, args: &[String]) {
     if args.len() != 1 {
         expect(core, args.len() as u64, 1);
         return;

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -1,0 +1,49 @@
+/*
+ * mode.rs: commands handling view mode (phy/vir).
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use core::*;
+use helper::*;
+use yansi::Paint;
+pub static MODEFUNCTION: CmdFunctions = CmdFunctions { run: mode_run, help: mode_help };
+
+fn mode_help(core: &mut Core) {
+    help(
+        core,
+        &"mode",
+        &"m",
+        vec![("vir", "Set view mode to virtual address space."), ("phy", "Set view mode to phyisical address space.")],
+    );
+}
+
+fn mode_run(core: &mut Core, args: &Vec<String>) {
+    if args.len() != 1 {
+        expect(core, args.len() as u64, 1);
+        return;
+    }
+    match &*args[0] {
+        "vir" => core.mode = AddrMode::Vir,
+        "phy" => core.mode = AddrMode::Phy,
+        _ => {
+            let msg = format!(
+                "Expected {} or {}, but found {}",
+                Paint::default("vir").italic().bold(),
+                Paint::default("phy").italic().bold(),
+                Paint::default(&args[0]).italic().bold(),
+            );
+            error_msg(core, "Invalid Mode", &msg);
+        }
+    }
+}

--- a/rcore/src/loc/mode.rs
+++ b/rcore/src/loc/mode.rs
@@ -17,33 +17,42 @@
 use core::*;
 use helper::*;
 use yansi::Paint;
-pub static MODEFUNCTION: CmdFunctions = CmdFunctions { run: mode_run, help: mode_help };
 
-fn mode_help(core: &mut Core) {
-    help(
-        core,
-        &"mode",
-        &"m",
-        vec![("vir", "Set view mode to virtual address space."), ("phy", "Set view mode to phyisical address space.")],
-    );
+#[derive(Default)]
+pub struct Mode {}
+
+impl Mode {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 
-fn mode_run(core: &mut Core, args: &[String]) {
-    if args.len() != 1 {
-        expect(core, args.len() as u64, 1);
-        return;
-    }
-    match &*args[0] {
-        "vir" => core.mode = AddrMode::Vir,
-        "phy" => core.mode = AddrMode::Phy,
-        _ => {
-            let msg = format!(
-                "Expected {} or {}, but found {}",
-                Paint::default("vir").italic().bold(),
-                Paint::default("phy").italic().bold(),
-                Paint::default(&args[0]).italic().bold(),
-            );
-            error_msg(core, "Invalid Mode", &msg);
+impl Cmd for Mode {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if args.len() != 1 {
+            expect(core, args.len() as u64, 1);
+            return;
         }
+        match &*args[0] {
+            "vir" => core.mode = AddrMode::Vir,
+            "phy" => core.mode = AddrMode::Phy,
+            _ => {
+                let msg = format!(
+                    "Expected {} or {}, but found {}",
+                    Paint::default("vir").italic().bold(),
+                    Paint::default("phy").italic().bold(),
+                    Paint::default(&args[0]).italic().bold(),
+                );
+                error_msg(core, "Invalid Mode", &msg);
+            }
+        }
+    }
+    fn help(&self, core: &mut Core) {
+        help(
+            core,
+            &"mode",
+            &"m",
+            vec![("vir", "Set view mode to virtual address space."), ("phy", "Set view mode to phyisical address space.")],
+        );
     }
 }

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -33,17 +33,17 @@ fn seek_help(core: &mut Core) {
     );
 }
 
-fn seek_run(core: &mut Core, args: &Vec<String>) {
+fn seek_run(core: &mut Core, args: &[String]) {
     if args.len() != 1 {
         expect(core, args.len() as u64, 1);
         return;
     }
-    if args[0].starts_with("+") {
+    if args[0].starts_with('+') {
         match str_to_num(&args[0][1..]) {
             Ok(offset) => core.set_loc(core.get_loc() + offset),
             Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
         }
-    } else if args[0].starts_with("-") {
+    } else if args[0].starts_with('-') {
         match str_to_num(&args[0][1..]) {
             Ok(offset) => core.set_loc(core.get_loc() - offset),
             Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -18,40 +18,49 @@
 use core::*;
 use helper::*;
 use std::io::Write;
-pub static SEEKFUNCTION: CmdFunctions = CmdFunctions { run: seek_run, help: seek_help };
 
-fn seek_help(core: &mut Core) {
-    help(
-        core,
-        &"seek",
-        &"s",
-        vec![
-            ("+[offset]", "Increase current loc by offset."),
-            ("-[offset]", "Decrease current loc by offset."),
-            ("[offset]", "Set current location to offset."),
-        ],
-    );
+#[derive(Default)]
+pub struct Seek {}
+
+impl Seek {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 
-fn seek_run(core: &mut Core, args: &[String]) {
-    if args.len() != 1 {
-        expect(core, args.len() as u64, 1);
-        return;
+impl Cmd for Seek {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if args.len() != 1 {
+            expect(core, args.len() as u64, 1);
+            return;
+        }
+        if args[0].starts_with('+') {
+            match str_to_num(&args[0][1..]) {
+                Ok(offset) => core.set_loc(core.get_loc() + offset),
+                Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+            }
+        } else if args[0].starts_with('-') {
+            match str_to_num(&args[0][1..]) {
+                Ok(offset) => core.set_loc(core.get_loc() - offset),
+                Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+            }
+        } else {
+            match str_to_num(&args[0]) {
+                Ok(offset) => core.set_loc(offset),
+                Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+            }
+        }
     }
-    if args[0].starts_with('+') {
-        match str_to_num(&args[0][1..]) {
-            Ok(offset) => core.set_loc(core.get_loc() + offset),
-            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
-        }
-    } else if args[0].starts_with('-') {
-        match str_to_num(&args[0][1..]) {
-            Ok(offset) => core.set_loc(core.get_loc() - offset),
-            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
-        }
-    } else {
-        match str_to_num(&args[0]) {
-            Ok(offset) => core.set_loc(offset),
-            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
-        }
+    fn help(&self, core: &mut Core) {
+        help(
+            core,
+            &"seek",
+            &"s",
+            vec![
+                ("+[offset]", "Increase current loc by offset."),
+                ("-[offset]", "Decrease current loc by offset."),
+                ("[offset]", "Set current location to offset."),
+            ],
+        );
     }
 }

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -244,4 +244,47 @@ mod test_seek {
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
         assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Seek Error\nAttempt to add with overflow.\n");
     }
+
+    #[test]
+    fn test_seek_invalid_arguments() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let mut seek: Seek = Default::default();
+        assert_eq!(core.mode, AddrMode::Phy);
+        assert_eq!(core.get_loc(), 0x0);
+
+        seek.run(&mut core, &[]);
+        assert_eq!(core.mode, AddrMode::Phy);
+        assert_eq!(core.get_loc(), 0x0);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Arguments Error: Expected 1 argument(s), found 0.\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        seek.run(&mut core, &["+ff".to_string()]);
+        assert_eq!(core.mode, AddrMode::Phy);
+        assert_eq!(core.get_loc(), 0x0);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Seek Error\ninvalid digit found in string\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        seek.run(&mut core, &["-ff".to_string()]);
+        assert_eq!(core.mode, AddrMode::Phy);
+        assert_eq!(core.get_loc(), 0x0);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Seek Error\ninvalid digit found in string\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+
+        seek.run(&mut core, &["ff".to_string()]);
+        assert_eq!(core.mode, AddrMode::Phy);
+        assert_eq!(core.get_loc(), 0x0);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "Error: Seek Error\ninvalid digit found in string\n");
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+    }
 }

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -1,0 +1,68 @@
+/*
+ * seek.rs: seek forward or backward in file.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use core::*;
+use std::io::Write;
+use std::num;
+pub static SEEKFUNCTON : CmdFunctions = CmdFunctions {
+    run: seek_run,
+    help: seek_help,
+};
+
+fn seek_help(core: &mut Core) {
+    writeln!(core.stdout, "Seek Command: [seek | s]").unwrap();
+    writeln!(core.stdout, "Usage:").unwrap();
+    writeln!(core.stdout, "s +offset\t Increase current loc by offset.").unwrap();
+    writeln!(core.stdout, "s -offset\t Decrease current loc by offset.").unwrap();
+    writeln!(core.stdout, "s offset\t Set current location to offset.").unwrap();
+}
+fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
+    if n.len() >= 2 {
+        match &*n[0..2].to_lowercase() {
+            "0b" => return u64::from_str_radix(&n[2..], 2),
+            "0x" => return u64::from_str_radix(&n[2..], 16),
+            _ => (),
+        }
+    }
+    if n.chars().nth(0).unwrap() == '0' {
+        return u64::from_str_radix(&n[1..], 8);
+    }
+    return u64::from_str_radix(n, 10);
+}
+
+fn seek_run(core: &mut Core, args: &Vec<String>) {
+    if args.len() != 1 {
+        writeln!(core.stderr, "Expected 1 argument found {}", args.len()).unwrap();
+        return;
+    }
+    if args[0].starts_with("+") {
+        match str_to_num(&args[0][1..]) {
+            Ok(offset) => core.set_loc(core.get_loc() + offset),
+            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+        }
+    } else if args[0].starts_with("-") {
+        match str_to_num(&args[0][1..]) {
+            Ok(offset) => core.set_loc(core.get_loc() - offset),
+            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+        }
+    } else {
+        match str_to_num(&args[0]) {
+            Ok(offset) => core.set_loc(offset),
+            Err(e) => writeln!(core.stderr, "{}", e.to_string()).unwrap(),
+        }
+    }
+}

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -16,37 +16,26 @@
  */
 
 use core::*;
+use helper::*;
 use std::io::Write;
-use std::num;
-pub static SEEKFUNCTON : CmdFunctions = CmdFunctions {
-    run: seek_run,
-    help: seek_help,
-};
+pub static SEEKFUNCTION: CmdFunctions = CmdFunctions { run: seek_run, help: seek_help };
 
 fn seek_help(core: &mut Core) {
-    writeln!(core.stdout, "Seek Command: [seek | s]").unwrap();
-    writeln!(core.stdout, "Usage:").unwrap();
-    writeln!(core.stdout, "s +offset\t Increase current loc by offset.").unwrap();
-    writeln!(core.stdout, "s -offset\t Decrease current loc by offset.").unwrap();
-    writeln!(core.stdout, "s offset\t Set current location to offset.").unwrap();
-}
-fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
-    if n.len() >= 2 {
-        match &*n[0..2].to_lowercase() {
-            "0b" => return u64::from_str_radix(&n[2..], 2),
-            "0x" => return u64::from_str_radix(&n[2..], 16),
-            _ => (),
-        }
-    }
-    if n.chars().nth(0).unwrap() == '0' {
-        return u64::from_str_radix(&n[1..], 8);
-    }
-    return u64::from_str_radix(n, 10);
+    help(
+        core,
+        &"seek",
+        &"s",
+        vec![
+            ("+[offset]", "Increase current loc by offset."),
+            ("-[offset]", "Decrease current loc by offset."),
+            ("[offset]", "Set current location to offset."),
+        ],
+    );
 }
 
 fn seek_run(core: &mut Core, args: &Vec<String>) {
     if args.len() != 1 {
-        writeln!(core.stderr, "Expected 1 argument found {}", args.len()).unwrap();
+        expect(core, args.len() as u64, 1);
         return;
     }
     if args[0].starts_with("+") {

--- a/rcore/src/loc/seek.rs
+++ b/rcore/src/loc/seek.rs
@@ -29,33 +29,33 @@ impl Seek {
         Seek { history }
     }
     fn backward(&mut self, core: &mut Core) {
-        match self.history.borrow_mut().backward(core) {
-            Some((mode, addr)) => {
-                core.mode = mode;
-                core.set_loc(addr);
-            }
-            None => error_msg(core, "Seek Error", "History is empty."),
+        if let Some((mode, addr)) = self.history.borrow_mut().backward(core) {
+            core.mode = mode;
+            core.set_loc(addr);
+        } else {
+            error_msg(core, "Seek Error", "History is empty.");
         }
     }
     fn forward(&mut self, core: &mut Core) {
-        match self.history.borrow_mut().forward(core) {
-            Some((mode, addr)) => {
-                core.mode = mode;
-                core.set_loc(addr);
-            }
-            None => error_msg(core, "Seek Error", "History is empty."),
+        if let Some((mode, addr)) = self.history.borrow_mut().forward(core) {
+            core.mode = mode;
+            core.set_loc(addr);
+        } else {
+            error_msg(core, "Seek Error", "History is empty.");
         }
     }
     fn add_loc(&mut self, core: &mut Core, offset: u64) {
-        match core.get_loc().checked_add(offset) {
-            Some(loc) => self.set_loc(core, loc),
-            None => error_msg(core, "Seek Error", "Attempt to add with overflow."),
+        if let Some(loc) = core.get_loc().checked_add(offset) {
+            self.set_loc(core, loc);
+        } else {
+            error_msg(core, "Seek Error", "Attempt to add with overflow.");
         }
     }
     fn sub_loc(&mut self, core: &mut Core, offset: u64) {
-        match core.get_loc().checked_sub(offset) {
-            Some(loc) => self.set_loc(core, loc),
-            None => error_msg(core, "Seek Error", "Attempt to subtract with overflow."),
+        if let Some(loc) = core.get_loc().checked_sub(offset) {
+            self.set_loc(core, loc);
+        } else {
+            error_msg(core, "Seek Error", "Attempt to subtract with overflow.");
         }
     }
     #[inline]

--- a/rcore/src/utils/mod.rs
+++ b/rcore/src/utils/mod.rs
@@ -18,8 +18,9 @@ mod quit;
 
 pub use self::quit::Quit;
 use core::Core;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub fn register_utils(core: &mut Core) {
-    core.add_command("quit", Box::new(Quit::new()));
-    core.add_command("q", Box::new(Quit::new()));
+    core.add_command("quit", "q", Rc::new(RefCell::new(Quit::new())));
 }

--- a/rcore/src/utils/mod.rs
+++ b/rcore/src/utils/mod.rs
@@ -1,8 +1,5 @@
-#![warn(clippy::cargo)]
-#![allow(clippy::multiple_crate_versions)]
-#![allow(clippy::needless_return)]
 /*
- * rcore: rair core library
+ * utils: Utility commands.
  * Copyright (C) 2019  Oddcoder
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,23 +14,5 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-extern crate app_dirs;
-extern crate rcmd;
-extern crate rio;
-extern crate rtrees;
-extern crate rustyline;
-extern crate rustyline_derive;
-extern crate yansi;
-mod commands;
-mod core;
-mod helper;
-mod io;
-mod lineformatter;
-mod loc;
-mod utils;
-mod writer;
-
-pub use core::*;
-pub use helper::*;
-pub use io::*;
-pub use writer::*;
+mod quit;
+pub use self::quit::*;

--- a/rcore/src/utils/mod.rs
+++ b/rcore/src/utils/mod.rs
@@ -15,4 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 mod quit;
-pub use self::quit::*;
+
+pub use self::quit::Quit;
+use core::Core;
+
+pub fn register_utils(core: &mut Core) {
+    core.add_command("quit", Box::new(Quit::new()));
+    core.add_command("q", Box::new(Quit::new()));
+}

--- a/rcore/src/utils/quit.rs
+++ b/rcore/src/utils/quit.rs
@@ -35,3 +35,21 @@ impl Cmd for Quit {
         help(core, &"quit", &"q", vec![("", "Quit Current session.")]);
     }
 }
+
+#[cfg(test)]
+mod test_quit {
+    use super::*;
+    use writer::Writer;
+    use yansi::Paint;
+    #[test]
+    fn test_quit_docs() {
+        Paint::disable();
+        let mut core = Core::new();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        let quit = Quit::new();
+        quit.help(&mut core);
+        assert_eq!(core.stdout.utf8_string().unwrap(), "Commands: [quit | q]\n\nUsage:\nq\tQuit Current session.\n");
+        assert_eq!(core.stderr.utf8_string().unwrap(), "");
+    }
+}

--- a/rcore/src/utils/quit.rs
+++ b/rcore/src/utils/quit.rs
@@ -1,8 +1,5 @@
-#![warn(clippy::cargo)]
-#![allow(clippy::multiple_crate_versions)]
-#![allow(clippy::needless_return)]
 /*
- * rcore: rair core library
+ * quit.rs: Quit the current project.
  * Copyright (C) 2019  Oddcoder
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -17,23 +14,15 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-extern crate app_dirs;
-extern crate rcmd;
-extern crate rio;
-extern crate rtrees;
-extern crate rustyline;
-extern crate rustyline_derive;
-extern crate yansi;
-mod commands;
-mod core;
-mod helper;
-mod io;
-mod lineformatter;
-mod loc;
-mod utils;
-mod writer;
+use core::*;
+use helper::*;
+use std::process;
+pub static QUITFUNCTION: CmdFunctions = CmdFunctions { run: quit_run, help: quit_help };
 
-pub use core::*;
-pub use helper::*;
-pub use io::*;
-pub use writer::*;
+fn quit_help(core: &mut Core) {
+    help(core, &"quit", &"q", vec![("", "Quit Current session.")]);
+}
+
+fn quit_run(_core: &mut Core, _args: &[String]) {
+    process::exit(0);
+}

--- a/rcore/src/utils/quit.rs
+++ b/rcore/src/utils/quit.rs
@@ -17,12 +17,21 @@
 use core::*;
 use helper::*;
 use std::process;
-pub static QUITFUNCTION: CmdFunctions = CmdFunctions { run: quit_run, help: quit_help };
 
-fn quit_help(core: &mut Core) {
-    help(core, &"quit", &"q", vec![("", "Quit Current session.")]);
+#[derive(Default)]
+pub struct Quit {}
+
+impl Quit {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 
-fn quit_run(_core: &mut Core, _args: &[String]) {
-    process::exit(0);
+impl Cmd for Quit {
+    fn run(&mut self, _core: &mut Core, _args: &[String]) {
+        process::exit(0);
+    }
+    fn help(&self, core: &mut Core) {
+        help(core, &"quit", &"q", vec![("", "Quit Current session.")]);
+    }
 }

--- a/rcore/src/writer.rs
+++ b/rcore/src/writer.rs
@@ -1,0 +1,126 @@
+/*
+ * writer.rs: Abstract implementation for Io::Write stream
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use std::io;
+use std::io::Write;
+
+/// This union acts as thin abstraction layer over over input streams.
+/// Its goal is to allow allow seamingless redirection of output to
+/// either a buffer, a file or even terminal IO.
+pub enum Writer {
+    #[doc(hidden)]
+    Write(Box<dyn Write>),
+    #[doc(hidden)]
+    Bytes(Vec<u8>),
+}
+
+impl Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Writer::Write(writer) => writer.write(buf),
+            Writer::Bytes(bytes) => bytes.write(buf),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Writer::Write(writer) => writer.flush(),
+            Writer::Bytes(bytes) => bytes.flush(),
+        }
+    }
+}
+
+impl Writer {
+    /// Creates a new [Writer] backed by object that implements [Write].
+    pub fn new_write(out: Box<dyn Write>) -> Self {
+        return Writer::Write(out);
+    }
+
+    /// Returns a new buffer based [Writer].
+    pub fn new_buf() -> Self {
+        return Writer::Bytes(Vec::new());
+    }
+    /// This function consumes the [Writer] object, it returns the
+    /// data stored there if the object is buffer based.
+    pub fn bytes(self) -> Option<Vec<u8>> {
+        if let Writer::Bytes(b) = self {
+            return Some(b);
+        } else {
+            return None;
+        }
+    }
+    /// This function consumes the [Writer] object, it returns UTF-8
+    /// String representation of the data stored there if it is buffer.
+    /// based and the buffer holds UTF-8 data.
+    pub fn utf8_string(self) -> Option<String> {
+        if let Writer::Bytes(b) = self {
+            if let Ok(s) = String::from_utf8(b) {
+                return Some(s);
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        }
+    }
+    /// This function returns a reference to the data stored
+    /// in respective [Writer] if the object is buffer based.
+    pub fn bytes_ref(&self) -> Option<&Vec<u8>> {
+        if let Writer::Bytes(b) = self {
+            return Some(b);
+        } else {
+            return None;
+        }
+    }
+
+    /// This function returns a mutable reference to the data
+    /// stored in respective [Writer] if the object is buffer.
+    /// based.
+    pub fn bytes_mut(&mut self) -> Option<&mut Vec<u8>> {
+        if let Writer::Bytes(b) = self {
+            return Some(b);
+        } else {
+            return None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod writer_test {
+    use super::*;
+    #[test]
+    fn test_writer_buffer() {
+        let mut w = Writer::new_buf();
+        let s = "Testing write buffer with utf8 heart ♥";
+        let v = s.as_bytes();
+        write!(w, "Testing write buffer with utf8 heart ♥").unwrap();
+        assert_eq!(w.bytes_ref().unwrap(), &v);
+        assert_eq!(w.bytes_mut().unwrap(), &v);
+        assert_eq!(w.utf8_string().unwrap(), s);
+        w = Writer::new_buf();
+        write!(w, "Testing write buffer with utf8 heart ♥").unwrap();
+        assert_eq!(w.bytes().unwrap(), v);
+    }
+
+    #[test]
+    fn test_writer_io() {
+        let mut w = Writer::new_write(Box::new(io::stdout()));
+        assert_eq!(w.bytes_ref(), None);
+        assert_eq!(w.bytes_mut(), None);
+        assert_eq!(w.utf8_string(), None);
+        w = Writer::new_write(Box::new(io::stdout()));
+        assert_eq!(w.bytes(), None);
+    }
+}

--- a/rio/Cargo.toml
+++ b/rio/Cargo.toml
@@ -16,5 +16,6 @@ rtrees = {path = "../rtrees"}
 bitflags = "1.2.0"
 memmap = "0.7.0"
 either_n = "0.2.0"
+
 [dev-dependencies]
-tempfile = "3.1.0"
+test_file = {path = "../test_file"}

--- a/rio/src/defaultplugin.rs
+++ b/rio/src/defaultplugin.rs
@@ -125,7 +125,7 @@ pub fn plugin() -> Box<dyn RIOPlugin> {
 #[cfg(test)]
 mod default_plugin_tests {
     use super::*;
-    use test_aids::*;
+    use test_file::*;
     #[test]
     fn test_plugin() {
         let plugin = plugin();

--- a/rio/src/defaultplugin.rs
+++ b/rio/src/defaultplugin.rs
@@ -42,18 +42,15 @@ impl RIOPluginOperations for FileInternals {
     }
 
     fn write(&mut self, raddr: usize, buf: &[u8]) -> Result<(), IoError> {
-        match self.map.as_mut().one() {
-            Some(mutmap) => {
-                if raddr + buf.len() > mutmap.len() {
-                    return Err(IoError::Parse(io::Error::new(io::ErrorKind::UnexpectedEof, "BufferOverflow")));
-                }
-                mutmap[raddr..raddr + buf.len()].copy_from_slice(buf);
+        if let Some(mutmap) = self.map.as_mut().one() {
+            if raddr + buf.len() > mutmap.len() {
+                return Err(IoError::Parse(io::Error::new(io::ErrorKind::UnexpectedEof, "BufferOverflow")));
             }
-            None => {
-                return Err(IoError::Parse(io::Error::new(io::ErrorKind::PermissionDenied, "File Not Writable")));
-            }
+            mutmap[raddr..raddr + buf.len()].copy_from_slice(buf);
+            return Ok(());
+        } else {
+            return Err(IoError::Parse(io::Error::new(io::ErrorKind::PermissionDenied, "File Not Writable")));
         }
-        return Ok(());
     }
 }
 

--- a/rio/src/desc.rs
+++ b/rio/src/desc.rs
@@ -75,7 +75,7 @@ mod default_plugin_tests {
     use defaultplugin;
     use std::io;
     use std::path::Path;
-    use test_aids::*;
+    use test_file::*;
     fn test_desc_read_cb(path: &Path) {
         let mut plugin = defaultplugin::plugin();
         let mut desc = RIODesc::open(&mut *plugin, &path.to_string_lossy(), IoMode::READ).unwrap();

--- a/rio/src/descquery.rs
+++ b/rio/src/descquery.rs
@@ -170,7 +170,7 @@ mod desc_query_tests {
     use super::*;
     use defaultplugin::plugin;
     use std::path::Path;
-    use test_aids::*;
+    use test_file::*;
     fn test_open_close_cb(path: &[&Path]) {
         let mut p = plugin();
         let mut descs = RIODescQuery::new();

--- a/rio/src/io.rs
+++ b/rio/src/io.rs
@@ -318,7 +318,7 @@ mod rio_tests {
     use super::*;
     use std::io;
     use std::path::Path;
-    use test_aids::*;
+    use test_file::*;
     fn test_failing_open_cb(path: &[&Path]) {
         let mut io = RIO::new();
         let mut bad_path = "badformat://".to_owned();

--- a/rio/src/io.rs
+++ b/rio/src/io.rs
@@ -163,17 +163,16 @@ impl RIO {
     /// ```
     pub fn pread(&mut self, paddr: u64, buf: &mut [u8]) -> Result<(), IoError> {
         let result = self.descs.paddr_range_to_hndl(paddr, buf.len() as u64);
-        match result {
-            Some(operations) => {
-                let mut start = 0;
-                for (hndl, paddr, size) in operations {
-                    let desc = self.descs.hndl_to_mut_desc(hndl).unwrap();
-                    desc.read(paddr as usize, &mut buf[start as usize..(start + size) as usize])?;
-                    start += size;
-                }
-                return Ok(());
+        if let Some(operations) = result {
+            let mut start = 0;
+            for (hndl, paddr, size) in operations {
+                let desc = self.descs.hndl_to_mut_desc(hndl).unwrap();
+                desc.read(paddr as usize, &mut buf[start as usize..(start + size) as usize])?;
+                start += size;
             }
-            None => return Err(IoError::AddressNotFound),
+            return Ok(());
+        } else {
+            return Err(IoError::AddressNotFound);
         }
     }
     /// Read from the physical address space of current [RIO] object. Data is stored in a sparce
@@ -216,17 +215,16 @@ impl RIO {
     /// ```
     pub fn pwrite(&mut self, paddr: u64, buf: &[u8]) -> Result<(), IoError> {
         let result = self.descs.paddr_range_to_hndl(paddr, buf.len() as u64);
-        match result {
-            Some(operations) => {
-                let mut start = 0;
-                for (hndl, paddr, size) in operations {
-                    let desc = self.descs.hndl_to_mut_desc(hndl).unwrap();
-                    desc.write(paddr as usize, &buf[start as usize..(start + size) as usize])?;
-                    start += size;
-                }
-                return Ok(());
+        if let Some(operations) = result {
+            let mut start = 0;
+            for (hndl, paddr, size) in operations {
+                let desc = self.descs.hndl_to_mut_desc(hndl).unwrap();
+                desc.write(paddr as usize, &buf[start as usize..(start + size) as usize])?;
+                start += size;
             }
-            None => return Err(IoError::AddressNotFound),
+            return Ok(());
+        } else {
+            return Err(IoError::AddressNotFound);
         }
     }
     ///  Map memory regions from physical address space to virtual address space
@@ -246,16 +244,15 @@ impl RIO {
     /// data to fill *buf* an error is returned.
     pub fn vread(&mut self, vaddr: u64, buf: &mut [u8]) -> Result<(), IoError> {
         let result = self.maps.split_vaddr_range(vaddr, buf.len() as u64);
-        match result {
-            Some(maps) => {
-                let mut start = 0;
-                for map in maps {
-                    self.pread(map.paddr, &mut buf[start as usize..(start + map.size) as usize])?;
-                    start += map.size;
-                }
-                return Ok(());
+        if let Some(maps) = result {
+            let mut start = 0;
+            for map in maps {
+                self.pread(map.paddr, &mut buf[start as usize..(start + map.size) as usize])?;
+                start += map.size;
             }
-            None => return Err(IoError::AddressNotFound),
+            return Ok(());
+        } else {
+            return Err(IoError::AddressNotFound);
         }
     }
     /// read memory from virtual address space. Data is stored in a sparce
@@ -276,17 +273,15 @@ impl RIO {
     /// write memory into virtual address space
     pub fn vwrite(&mut self, vaddr: u64, buf: &[u8]) -> Result<(), IoError> {
         let result = self.maps.split_vaddr_range(vaddr, buf.len() as u64);
-        match result {
-            Some(maps) => {
-                let mut start = 0;
-                for map in maps {
-                    self.pwrite(map.paddr, &buf[start as usize..(start + map.size) as usize])?;
-                    start += map.size;
-                }
-
-                return Ok(());
+        if let Some(maps) = result {
+            let mut start = 0;
+            for map in maps {
+                self.pwrite(map.paddr, &buf[start as usize..(start + map.size) as usize])?;
+                start += map.size;
             }
-            None => return Err(IoError::AddressNotFound),
+            return Ok(());
+        } else {
+            return Err(IoError::AddressNotFound);
         }
     }
 

--- a/rio/src/lib.rs
+++ b/rio/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
 /*
  * rio: rair IO library impelementation

--- a/rio/src/lib.rs
+++ b/rio/src/lib.rs
@@ -18,12 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[macro_use] extern crate bitflags;
+#[macro_use]
+extern crate bitflags;
 extern crate either_n;
 extern crate memmap;
 extern crate rtrees;
-#[cfg(test)] extern crate test_file;
-
+#[cfg(test)]
+extern crate test_file;
 
 mod defaultplugin;
 mod desc;

--- a/rio/src/lib.rs
+++ b/rio/src/lib.rs
@@ -18,15 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[macro_use]
-extern crate bitflags;
+#[macro_use] extern crate bitflags;
 extern crate either_n;
 extern crate memmap;
 extern crate rtrees;
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-mod test_aids;
+#[cfg(test)] extern crate test_file;
+
 
 mod defaultplugin;
 mod desc;

--- a/rio/src/utils.rs
+++ b/rio/src/utils.rs
@@ -40,47 +40,36 @@ impl PartialEq for IoError {
         match self {
             IoError::AddressNotFound => {
                 if let IoError::AddressNotFound = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
             IoError::AddressesOverlapError => {
                 if let IoError::AddressesOverlapError = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
             IoError::IoPluginNotFoundError => {
                 if let IoError::IoPluginNotFoundError = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
             IoError::TooManyFilesError => {
                 if let IoError::TooManyFilesError = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
             IoError::HndlNotFoundError => {
                 if let IoError::HndlNotFoundError = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
             IoError::Parse(_) => {
                 if let IoError::Parse(_) = rhs {
-                    true
-                } else {
-                    false
+                    return true;
                 }
             }
         }
+        return false;
     }
 }
 impl fmt::Display for IoError {

--- a/rtrees/src/bktree/tree.rs
+++ b/rtrees/src/bktree/tree.rs
@@ -57,9 +57,8 @@ where
         let current_distance = self.key.distance(&key);
         if current_distance == 0 {
             exact.push(&self.value);
-        }else if current_distance <= tolerance {
+        } else if current_distance <= tolerance {
             close.push(&self.key);
-
         }
         for i in current_distance.saturating_sub(tolerance)..=current_distance.saturating_add(tolerance) {
             if let Some(child) = self.children.get(&i) {

--- a/rtrees/src/bktree/tree.rs
+++ b/rtrees/src/bktree/tree.rs
@@ -44,12 +44,11 @@ where
     }
     fn insert(&mut self, key: K, value: V) {
         let distance = self.key.distance(&key);
-        match self.children.get_mut(&distance) {
-            Some(child) => child.insert(key, value),
-            None => {
-                self.children.insert(distance, BKTreeNode::new(key, value));
-            }
-        };
+        if let Some(child) = self.children.get_mut(&distance) {
+            child.insert(key, value);
+        } else {
+            self.children.insert(distance, BKTreeNode::new(key, value));
+        }
     }
 
     fn find(&self, key: &K, tolerance: u64) -> (Vec<&V>, Vec<&K>) {
@@ -89,9 +88,10 @@ where
 
     /// Inserts a new (*key*, *value*) pair into the KB-Tree
     pub fn insert(&mut self, key: K, value: V) {
-        match &mut self.root {
-            Some(root) => root.insert(key, value),
-            None => self.root = Some(BKTreeNode::new(key, value)),
+        if let Some(root) = &mut self.root {
+            root.insert(key, value);
+        } else {
+            self.root = Some(BKTreeNode::new(key, value));
         }
     }
 
@@ -102,10 +102,7 @@ where
     /// Two keys *key1* and *key2* are said to be approximate match IFF
     /// `key1.distance(key2) <= tolerance`.
     pub fn find(&self, key: &K, tolerance: u64) -> (Vec<&V>, Vec<&K>) {
-        return match &self.root {
-            Some(root) => root.find(&key, tolerance),
-            None => (Vec::new(), Vec::new()),
-        };
+        return if let Some(root) = &self.root { root.find(&key, tolerance) } else { (Vec::new(), Vec::new()) };
     }
 }
 

--- a/rtrees/src/ist/iter.rs
+++ b/rtrees/src/ist/iter.rs
@@ -41,9 +41,10 @@ impl<K: Ord + Copy, V> Iterator for ISTIterator<K, V> {
         if let Some(data) = self.current_iter.next() {
             return Some(data);
         }
-        match self.tree_iter.next() {
-            Some((_, v)) => self.current_iter = v.into_iter(),
-            None => return None,
+        if let Some((_, v)) = self.tree_iter.next() {
+            self.current_iter = v.into_iter();
+        } else {
+            return None;
         }
         return self.current_iter.next();
     }

--- a/rtrees/src/ist/iter_ref.rs
+++ b/rtrees/src/ist/iter_ref.rs
@@ -40,9 +40,10 @@ impl<'a, K: Ord + Copy, V> Iterator for ISTRefIterator<'a, K, V> {
         if let Some(data) = self.current_iter.next() {
             return Some(data);
         }
-        match self.tree_iter.next() {
-            Some((_, v)) => self.current_iter = v.iter(),
-            None => return None,
+        if let Some((_, v)) = self.tree_iter.next() {
+            self.current_iter = v.iter();
+        } else {
+            return None;
         }
         return self.current_iter.next();
     }

--- a/rtrees/src/ist/mod.rs
+++ b/rtrees/src/ist/mod.rs
@@ -19,6 +19,6 @@ mod iter;
 mod iter_ref;
 mod rb_helpers;
 mod tree;
-pub use self::tree::*;
 pub use self::iter::ISTIterator;
 pub use self::iter_ref::ISTRefIterator;
+pub use self::tree::*;

--- a/rtrees/src/ist/tree.rs
+++ b/rtrees/src/ist/tree.rs
@@ -130,12 +130,11 @@ impl<K: Ord + Copy, V> IST<K, V> {
         assert!(lo <= hi);
         let interval = Interval::new(lo, hi);
         let aug_data = AugData::new(interval, 1);
-        match self.root.search_mut(interval) {
-            Some(data_vec) => {
-                data_vec.push(data);
-                self.root.force_sync_aug(interval);
-            }
-            None => self.root.insert(interval, aug_data, vec![data]),
+        if let Some(data_vec) = self.root.search_mut(interval) {
+            data_vec.push(data);
+            self.root.force_sync_aug(interval);
+        } else {
+            self.root.insert(interval, aug_data, vec![data]);
         }
     }
 

--- a/rtrees/src/lib.rs
+++ b/rtrees/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
 /*
  * rtrees: rair trees library impelementation

--- a/rtrees/src/rbtree/iter.rs
+++ b/rtrees/src/rbtree/iter.rs
@@ -57,9 +57,10 @@ where
 
     fn next(&mut self) -> Option<(K, V)> {
         let result;
-        match self.current.take() {
-            None => return None,
-            Some(node) => result = Some((node.key(), node.data())),
+        if let Some(node) = self.current.take() {
+            result = Some((node.key(), node.data()));
+        } else {
+            return None;
         }
         if let Some(node) = self.right.pop() {
             self.add_subtree(node);

--- a/rtrees/src/rbtree/iter.rs
+++ b/rtrees/src/rbtree/iter.rs
@@ -46,7 +46,7 @@ where
                 break;
             }
         }
-        self.current = Some(node);
+        self.current = if node.is_node() { Some(node) } else { None };
     }
 }
 impl<K: Ord + Copy, A: Copy, V> Iterator for TreeIterator<K, A, V>

--- a/rtrees/src/rbtree/iter_ref.rs
+++ b/rtrees/src/rbtree/iter_ref.rs
@@ -66,9 +66,10 @@ where
 
     fn next(&mut self) -> Option<(K, &'a V)> {
         let result;
-        match self.current.take() {
-            None => return None,
-            Some(node) => result = Some((node.key(), node.data_ref())),
+        if let Some(node) = self.current.take() {
+            result = Some((node.key(), node.data_ref()));
+        } else {
+            return None;
         }
         if let Some(node) = self.right.pop() {
             match node {

--- a/rtrees/src/rbtree/iter_ref.rs
+++ b/rtrees/src/rbtree/iter_ref.rs
@@ -55,7 +55,7 @@ where
                 break;
             }
         }
-        self.current = Some(node);
+        self.current = if node.is_node() { Some(node) } else { None }
     }
 }
 impl<'a, K: Ord + Copy, A: Copy, V> Iterator for TreeRefIterator<'a, K, A, V>

--- a/rtrees/src/rbtree/rbtree_wrapper.rs
+++ b/rtrees/src/rbtree/rbtree_wrapper.rs
@@ -233,10 +233,7 @@ where
     /// assert_eq!(rbtree.size(), 3);
     /// ```
     pub fn size(&self) -> u64 {
-        match &self.0 {
-            Some(node) => return node.size(),
-            None => return 0,
-        }
+        return if let Some(node) = &self.0 { node.size() } else { 0 };
     }
 
     /// 0 will be returned in case of empty tree. If tree has nodes, then *get_level*
@@ -256,10 +253,7 @@ where
     /// assert!(rbtree.get_level() >= 10 && rbtree.get_level() <= 20);
     /// ```
     pub fn get_level(&self) -> u64 {
-        match self.as_ref() {
-            Some(node) => return node.get_level(),
-            None => return 0,
-        }
+        return if let Some(node) = self.as_ref() { node.get_level() } else { 0 };
     }
 
     pub(crate) fn sync_aug(&mut self) {
@@ -360,12 +354,8 @@ where
             return;
         }
         match key.cmp(&self.key()) {
-            Ordering::Greater => {
-                self.right_mut().force_sync_aug(key);
-            }
-            Ordering::Less => {
-                self.left_mut().force_sync_aug(key);
-            }
+            Ordering::Greater => self.right_mut().force_sync_aug(key),
+            Ordering::Less => self.left_mut().force_sync_aug(key),
             _ => (),
         }
         self.sync_aug();

--- a/rtrees/src/rbtree/rbtree_wrapper.rs
+++ b/rtrees/src/rbtree/rbtree_wrapper.rs
@@ -666,4 +666,27 @@ mod rbtree_tests {
             assert_eq!(i, iter.next().unwrap().0)
         }
     }
+
+    #[test]
+    fn test_iter_empty() {
+        // I am fully aware that the assers will never be evaluated.
+        // The point here is that at some point in time, iterating over
+        // empty tree, triggered a bug that crashed.
+        let rbtree: RBTree<u64, PlaceHolder, u64> = RBTree::new();
+        for (key, value) in rbtree.into_iter() {
+            assert_eq!(key, 5);
+            assert_eq!(value, 5);
+        }
+    }
+    #[test]
+    fn test_iter_ref_empty() {
+        // I am fully aware that the assers will never be evaluated.
+        // The point here is that at some point in time, iterating over
+        // empty tree, triggered a bug that crashed.
+        let rbtree: RBTree<u64, PlaceHolder, u64> = RBTree::new();
+        for (key, value) in (&rbtree).into_iter() {
+            assert_eq!(key, 5);
+            assert_eq!(*value, 5);
+        }
+    }
 }

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -1,9 +1,23 @@
 #![warn(clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
-
-#[macro_use]
-extern crate clap;
+/*
+ * rair.rs: rair CLI.
+ * Copyright (C) 2019  Oddcoder
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#[macro_use] extern crate clap;
 extern crate app_dirs;
 extern crate rcmd;
 extern crate rcore;
@@ -74,15 +88,9 @@ fn repl_inners(core: &mut Core) {
                 writeln!(core.stderr, "{}", t.err().unwrap().to_string()).unwrap();
             }
         }
-        Err(ReadlineError::Interrupted) => {
-            writeln!(core.stdout, "CTRL-C").unwrap();
-        }
-        Err(ReadlineError::Eof) => {
-            std::process::exit(0);
-        }
-        Err(err) => {
-            writeln!(core.stdout, "Error: {:?}", err).unwrap();
-        }
+        Err(ReadlineError::Interrupted) => writeln!(core.stdout, "CTRL-C").unwrap(),
+        Err(ReadlineError::Eof) => std::process::exit(0),
+        Err(err) =>  writeln!(core.stdout, "Error: {:?}", err).unwrap(),
     }
     core.rl.save_history(&core.hist_file()).unwrap();
 }
@@ -102,10 +110,7 @@ fn run_cmd(core: &mut Core, cmd: Cmd) {
     for arg in cmd.args {
         match eval_arg(core, arg) {
             Ok(arg) => args.push(arg),
-            Err(e) => {
-                writeln!(core.stderr, "{}", e).unwrap();
-                return;
-            }
+            Err(e) => return writeln!(core.stderr, "{}", e).unwrap(),
         }
     }
     // process redirections or pipes
@@ -114,27 +119,18 @@ fn run_cmd(core: &mut Core, cmd: Cmd) {
     match *cmd.red_pipe {
         RedPipe::Redirect(arg) => match create_redirect(core, *arg) {
             Ok(out) => stdout = Some(mem::replace(&mut core.stdout, out)),
-            Err(e) => {
-                writeln!(core.stderr, "{}", e).unwrap();
-                return;
-            }
+            Err(e) => return writeln!(core.stderr, "{}", e).unwrap(),
         },
         RedPipe::RedirectCat(arg) => match create_redirect_cat(core, *arg) {
             Ok(out) => stdout = Some(mem::replace(&mut core.stdout, out)),
-            Err(e) => {
-                writeln!(core.stderr, "{}", e).unwrap();
-                return;
-            }
+            Err(e) => return writeln!(core.stderr, "{}", e).unwrap(),
         },
         RedPipe::Pipe(arg) => match create_pipe(core, arg) {
             Ok((process, writer)) => {
                 child = Some(process);
                 stdout = Some(mem::replace(&mut core.stdout, writer));
             }
-            Err(e) => {
-                writeln!(core.stderr, "{}", e).unwrap();
-                return;
-            }
+            Err(e) => return writeln!(core.stderr, "{}", e).unwrap(),
         },
         RedPipe::None => (),
     }

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::needless_return)]
 
 #[macro_use]

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::cargo)]
+#![allow(clippy::needless_return)]
+
 #[macro_use]
 extern crate clap;
 

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -10,6 +10,7 @@ extern crate rcore;
 extern crate rio;
 extern crate rtrees;
 extern crate rustyline;
+extern crate yansi;
 
 use clap::{App, Arg};
 use color_backtrace::{install_with_settings, Settings};
@@ -20,6 +21,7 @@ use rustyline::error::ReadlineError;
 use std::fs::{File, OpenOptions};
 use std::process::{Child, Command, Stdio};
 use std::{io::prelude::*, io::Write, mem, num};
+use yansi::Paint;
 
 fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     if n.len() >= 2 {
@@ -74,7 +76,9 @@ fn main() {
 }
 
 fn repl_inners(core: &mut Core) {
-    let input = core.rl.readline(&format!("[0x{:08x}]> ", core.get_loc()));
+    let prelude = &format!("[0x{:08x}]({})> ", core.get_loc(), core.mode);
+    let (r, g, b) = core.color_palette[1];
+    let input = core.rl.readline(&format!("{}", Paint::rgb(r, g, b, prelude)));
     match &input {
         Ok(line) => {
             core.rl.add_history_entry(line);

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -5,7 +5,6 @@
 #[macro_use]
 extern crate clap;
 extern crate app_dirs;
-extern crate color_backtrace;
 extern crate rcmd;
 extern crate rcore;
 extern crate rio;
@@ -14,7 +13,6 @@ extern crate rustyline;
 extern crate yansi;
 
 use clap::{App, Arg};
-use color_backtrace::{install_with_settings, Settings};
 use rcmd::*;
 use rcore::*;
 use rio::*;
@@ -25,7 +23,6 @@ use std::{io::prelude::*, io::Write, mem};
 use yansi::Paint;
 
 fn main() {
-    install_with_settings(Settings::new().message("Unrecoverable Error: "));
     let matches = App::new("rair")
         .version(crate_version!())
         .version_short("v")

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -14,7 +14,7 @@ extern crate yansi;
 
 use clap::{App, Arg};
 use rcmd::*;
-use rcore::{str_to_num, Core, Writer};
+use rcore::{str_to_num, Core, Writer, panic_msg};
 use rio::*;
 use rustyline::error::ReadlineError;
 use std::fs::{File, OpenOptions};
@@ -46,14 +46,14 @@ fn main() {
             match c {
                 'r' => perm |= IoMode::READ,
                 'w' => perm |= IoMode::WRITE,
-                _ => panic!("Unknown Permission: `{}`", c),
+                _ => panic_msg(&mut core, &format!("Unknown Permission: `{}`", c), ""),
             }
         }
     }
     if let Some(addr) = matches.value_of("Paddr") {
-        paddr = str_to_num(addr).unwrap_or_else(|e| panic!(e.to_string()));
+        paddr = str_to_num(addr).unwrap_or_else(|e| panic_msg(&mut core, &e.to_string(), ""));
     }
-    core.io.open_at(uri, perm, paddr).unwrap_or_else(|e| panic!(e.to_string()));
+    core.io.open_at(uri, perm, paddr).unwrap_or_else(|e| panic_msg(&mut core, &e.to_string(), ""));
     core.set_loc(paddr);
     loop {
         repl_inners(&mut core);

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -1,25 +1,41 @@
 #[macro_use]
 extern crate clap;
-extern crate rio;
+extern crate app_dirs;
 extern crate color_backtrace;
-use rio::*;
+extern crate rio;
+extern crate rustyline;
+use app_dirs::*;
 use clap::{App, Arg};
 use color_backtrace::{install_with_settings, Settings};
+use rio::*;
+use rustyline::{error::ReadlineError, Editor};
 use std::num;
-
-#[derive(Default)]
-struct Core{
+use std::path::PathBuf;
+struct Core {
     io: RIO,
-    cur: u64
+    rl: Editor<()>,
+    cur: u64,
+    app_info: AppInfo,
 }
 impl Core {
-    fn new() -> Self{
-        let mut core: Core = Default::default();
-        core.io = RIO::new();
+    fn new() -> Self {
+        let mut core = Core {
+            io: RIO::new(),
+            cur: 0,
+            rl: Editor::<()>::new(),
+            app_info: AppInfo { name: "rair", author: "RairDevs" },
+        };
+        drop(core.rl.load_history(&core.hist_file()));
         return core;
     }
+    fn hist_file(&self) -> PathBuf {
+        let mut history = app_dir(AppDataType::UserData, &self.app_info, "/").unwrap();
+        history.push("history");
+        return history;
+    }
 }
-fn str_to_num(n: &str)  -> Result<u64, num::ParseIntError> {
+
+fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     match &*n[0..2].to_lowercase() {
         "0b" => return u64::from_str_radix(&n[2..], 2),
         "0x" => return u64::from_str_radix(&n[2..], 16),
@@ -33,30 +49,25 @@ fn str_to_num(n: &str)  -> Result<u64, num::ParseIntError> {
 fn main() {
     install_with_settings(Settings::new().message("Unrecoverable Error: "));
     let matches = App::new("rair")
-                    .version(crate_version!())
-                    .version_short("v")
-                    .arg(Arg::with_name("Permission")
-                            .help("File permision: Permission can be R or RW case insensitive, the default is R")
-                            .short("p")
-                            .long("perm")
-                            .takes_value(true))
-                    .arg(Arg::with_name("Paddr")
-                            .help("Physical Base address")
-                            .short("P")
-                            .long("phy")
-                            .takes_value(true))
-                    .arg(Arg::with_name("File")
-                            .help("Binary file to be loaded")
-                            .takes_value(true)
-                            .required(true))
-                      .get_matches();
+        .version(crate_version!())
+        .version_short("v")
+        .arg(
+            Arg::with_name("Permission")
+                .help("File permision: Permission can be R or RW case insensitive, the default is R")
+                .short("p")
+                .long("perm")
+                .takes_value(true),
+        )
+        .arg(Arg::with_name("Paddr").help("Physical Base address").short("P").long("phy").takes_value(true))
+        .arg(Arg::with_name("File").help("Binary file to be loaded").takes_value(true).required(true))
+        .get_matches();
     let mut core = Core::new();
     let mut perm: IoMode = IoMode::READ;
-    let mut paddr :u64 = 0;
+    let mut paddr: u64 = 0;
     let uri = matches.value_of("File").unwrap();
     if let Some(p) = matches.value_of("Permission") {
-        perm = Default::default() ;
-        for c in p. to_lowercase().chars() {
+        perm = Default::default();
+        for c in p.to_lowercase().chars() {
             match c {
                 'R' => perm |= IoMode::READ,
                 'W' => perm |= IoMode::WRITE,
@@ -69,4 +80,27 @@ fn main() {
     }
     core.io.open_at(uri, perm, paddr).unwrap_or_else(|e| panic!(e.to_string()));
     core.cur = paddr;
+    loop {
+        repl_inners(&mut core);
+    }
+}
+
+fn repl_inners(core: &mut Core) {
+    let input = core.rl.readline(&format!("[0x{:08x}]> ", core.cur));
+    match &input {
+        Ok(line) => {
+            core.rl.add_history_entry(line);
+            //print_eval_result(eval_str(e, &line));
+        }
+        Err(ReadlineError::Interrupted) => {
+            println!("CTRL-C");
+        }
+        Err(ReadlineError::Eof) => {
+            std::process::exit(0);
+        }
+        Err(err) => {
+            println!("Error: {:?}", err);
+        }
+    }
+    core.rl.save_history(&core.hist_file()).unwrap();
 }

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -3,44 +3,23 @@
 
 #[macro_use]
 extern crate clap;
-
 extern crate app_dirs;
 extern crate color_backtrace;
 extern crate rcmd;
+extern crate rcore;
 extern crate rio;
+extern crate rtrees;
 extern crate rustyline;
-use app_dirs::*;
+
 use clap::{App, Arg};
 use color_backtrace::{install_with_settings, Settings};
-use rcmd::ParseTree;
+use rcmd::*;
+use rcore::*;
 use rio::*;
-use rustyline::{error::ReadlineError, Editor};
-use std::num;
-use std::path::PathBuf;
-
-struct Core {
-    io: RIO,
-    rl: Editor<()>,
-    cur: u64,
-    app_info: AppInfo,
-}
-impl Core {
-    fn new() -> Self {
-        let mut core = Core {
-            io: RIO::new(),
-            cur: 0,
-            rl: Editor::<()>::new(),
-            app_info: AppInfo { name: "rair", author: "RairDevs" },
-        };
-        drop(core.rl.load_history(&core.hist_file()));
-        return core;
-    }
-    fn hist_file(&self) -> PathBuf {
-        let mut history = app_dir(AppDataType::UserData, &self.app_info, "/").unwrap();
-        history.push("history");
-        return history;
-    }
-}
+use rustyline::error::ReadlineError;
+use std::fs::{File, OpenOptions};
+use std::process::{Child, Command, Stdio};
+use std::{io::prelude::*, io::Write, mem, num};
 
 fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
     if n.len() >= 2 {
@@ -88,33 +67,162 @@ fn main() {
         paddr = str_to_num(addr).unwrap_or_else(|e| panic!(e.to_string()));
     }
     core.io.open_at(uri, perm, paddr).unwrap_or_else(|e| panic!(e.to_string()));
-    core.cur = paddr;
+    core.set_loc(paddr);
     loop {
         repl_inners(&mut core);
     }
 }
 
 fn repl_inners(core: &mut Core) {
-    let input = core.rl.readline(&format!("[0x{:08x}]> ", core.cur));
+    let input = core.rl.readline(&format!("[0x{:08x}]> ", core.get_loc()));
     match &input {
         Ok(line) => {
             core.rl.add_history_entry(line);
             let t = ParseTree::construct(line);
             if let Ok(tree) = t {
-                println!("{:#?}", tree);
+                evaluate(core, tree);
             } else {
-                println!("{}", t.err().unwrap().to_string());
+                writeln!(core.stderr, "{}", t.err().unwrap().to_string()).unwrap();
             }
         }
         Err(ReadlineError::Interrupted) => {
-            println!("CTRL-C");
+            writeln!(core.stdout, "CTRL-C").unwrap();
         }
         Err(ReadlineError::Eof) => {
             std::process::exit(0);
         }
         Err(err) => {
-            println!("Error: {:?}", err);
+            writeln!(core.stdout, "Error: {:?}", err).unwrap();
         }
     }
     core.rl.save_history(&core.hist_file()).unwrap();
+}
+
+fn evaluate(core: &mut Core, tree: ParseTree) {
+    match tree {
+        ParseTree::Help(help) => core.help(&help.command),
+        ParseTree::Cmd(cmd) => run_cmd(core, cmd),
+        ParseTree::NewLine => (),
+        ParseTree::Comment => (),
+    }
+}
+
+fn run_cmd(core: &mut Core, cmd: Cmd) {
+    let mut args = Vec::new();
+    //process args
+    for arg in cmd.args {
+        match eval_arg(core, arg) {
+            Ok(arg) => args.push(arg),
+            Err(e) => {
+                writeln!(core.stderr, "{}", e).unwrap();
+                return;
+            }
+        }
+    }
+    // process redirections or pipes
+    let mut stdout: Option<Writer> = None;
+    let mut child: Option<Child> = None;
+    match *cmd.red_pipe {
+        RedPipe::Redirect(arg) => match create_redirect(core, *arg) {
+            Ok(out) => stdout = Some(mem::replace(&mut core.stdout, out)),
+            Err(e) => {
+                writeln!(core.stderr, "{}", e).unwrap();
+                return;
+            }
+        },
+        RedPipe::RedirectCat(arg) => match create_redirect_cat(core, *arg) {
+            Ok(out) => stdout = Some(mem::replace(&mut core.stdout, out)),
+            Err(e) => {
+                writeln!(core.stderr, "{}", e).unwrap();
+                return;
+            }
+        },
+        RedPipe::Pipe(arg) => match create_pipe(core, *arg) {
+            Ok((process, writer)) => {
+                child = Some(process);
+                stdout = Some(mem::replace(&mut core.stdout, writer));
+            }
+            Err(e) => {
+                writeln!(core.stderr, "{}", e).unwrap();
+                return;
+            }
+        },
+        RedPipe::None => (),
+    }
+    // execute
+    match cmd.loc {
+        Some(at) => core.run_at(&cmd.command, &args, at),
+        None => core.run(&cmd.command, &args),
+    }
+    //if we have a pipe feed into the pipe ..
+    if let Some(process) = child {
+        if let Writer::Bytes(b) = &mut core.stdout {
+            let mut s = String::new();
+            process.stdin.unwrap().write_all(&b).unwrap();
+            process.stdout.unwrap().read_to_string(&mut s).unwrap();
+            writeln!(stdout.as_mut().unwrap(), "{}", s).unwrap();
+        }
+    }
+    // if we have a temporary stdout restore it
+    if let Some(outstream) = stdout {
+        mem::replace(&mut core.stdout, outstream);
+    }
+}
+
+fn create_redirect(core: &mut Core, arg: Argument) -> Result<Writer, String> {
+    let file_name = eval_arg(core, arg)?;
+    match File::create(file_name) {
+        Ok(f) => return Ok(Writer::Write(Box::new(f))),
+        Err(e) => return Err(e.to_string()),
+    }
+}
+
+fn create_redirect_cat(core: &mut Core, arg: Argument) -> Result<Writer, String> {
+    let file_name = eval_arg(core, arg)?;
+    match OpenOptions::new().write(true).append(true).open(file_name) {
+        Ok(f) => return Ok(Writer::Write(Box::new(f))),
+        Err(e) => return Err(e.to_string()),
+    }
+}
+
+fn create_pipe(core: &mut Core, arg: Argument) -> Result<(Child, Writer), String> {
+    let process_name = eval_arg(core, arg)?;
+    match Command::new(process_name).stdin(Stdio::piped()).stdout(Stdio::piped()).spawn() {
+        Err(why) => return Err(why.to_string()),
+        Ok(process) => return Ok((process, Writer::Bytes(Vec::new()))),
+    };
+}
+
+fn eval_arg(core: &mut Core, arg: Argument) -> Result<String, String> {
+    match arg {
+        Argument::Literal(s) => return Ok(s),
+        Argument::Err(e) => return Err(e.to_string()),
+        Argument::NonLiteral(c) => return eval_non_literal_arg(core, c),
+    }
+}
+fn eval_non_literal_arg(core: &mut Core, cmd: Cmd) -> Result<String, String> {
+    // change stderr and stdout
+    let mut stderr = Writer::Bytes(Vec::new());
+    let mut stdout = Writer::Bytes(Vec::new());
+    mem::swap(&mut core.stderr, &mut stderr);
+    mem::swap(&mut core.stdout, &mut stdout);
+    // run command
+    run_cmd(core, cmd);
+    // restore stderr and stdout
+    mem::swap(&mut core.stderr, &mut stderr);
+    mem::swap(&mut core.stdout, &mut stdout);
+
+    if let Writer::Bytes(err) = stderr {
+        if err.is_empty() {
+            return Err(String::from_utf8(err).unwrap());
+        } else {
+            if let Writer::Bytes(out) = stdout {
+                return Ok(String::from_utf8(out).unwrap());
+            } else {
+                return Err("BUG: Expected Bytes based Writerin STDOUT".to_string());
+            }
+        }
+    } else {
+        return Err("BUG: Expected Bytes based Writer in STDERR".to_string());
+    }
 }

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -14,7 +14,7 @@ extern crate yansi;
 
 use clap::{App, Arg};
 use rcmd::*;
-use rcore::*;
+use rcore::{str_to_num, Core, Writer};
 use rio::*;
 use rustyline::error::ReadlineError;
 use std::fs::{File, OpenOptions};

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -14,7 +14,7 @@ extern crate yansi;
 
 use clap::{App, Arg};
 use rcmd::*;
-use rcore::{str_to_num, Core, Writer, panic_msg};
+use rcore::{panic_msg, str_to_num, Core, Writer};
 use rio::*;
 use rustyline::error::ReadlineError;
 use std::fs::{File, OpenOptions};

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -20,22 +20,9 @@ use rio::*;
 use rustyline::error::ReadlineError;
 use std::fs::{File, OpenOptions};
 use std::process::{Child, Command, Stdio};
-use std::{io::prelude::*, io::Write, mem, num};
+use std::{io::prelude::*, io::Write, mem};
 use yansi::Paint;
 
-fn str_to_num(n: &str) -> Result<u64, num::ParseIntError> {
-    if n.len() >= 2 {
-        match &*n[0..2].to_lowercase() {
-            "0b" => return u64::from_str_radix(&n[2..], 2),
-            "0x" => return u64::from_str_radix(&n[2..], 16),
-            _ => (),
-        }
-    }
-    if n.chars().nth(0).unwrap() == '0' {
-        return u64::from_str_radix(&n[1..], 8);
-    }
-    return u64::from_str_radix(n, 10);
-}
 fn main() {
     install_with_settings(Settings::new().message("Unrecoverable Error: "));
     let matches = App::new("rair")

--- a/src/rair.rs
+++ b/src/rair.rs
@@ -1,2 +1,72 @@
+#[macro_use]
+extern crate clap;
+extern crate rio;
+extern crate color_backtrace;
+use rio::*;
+use clap::{App, Arg};
+use color_backtrace::{install_with_settings, Settings};
+use std::num;
+
+#[derive(Default)]
+struct Core{
+    io: RIO,
+    cur: u64
+}
+impl Core {
+    fn new() -> Self{
+        let mut core: Core = Default::default();
+        core.io = RIO::new();
+        return core;
+    }
+}
+fn str_to_num(n: &str)  -> Result<u64, num::ParseIntError> {
+    match &*n[0..2].to_lowercase() {
+        "0b" => return u64::from_str_radix(&n[2..], 2),
+        "0x" => return u64::from_str_radix(&n[2..], 16),
+        _ => (),
+    }
+    if n.chars().nth(0).unwrap() == '0' {
+        return u64::from_str_radix(&n[1..], 8);
+    }
+    return u64::from_str_radix(n, 10);
+}
 fn main() {
+    install_with_settings(Settings::new().message("Unrecoverable Error: "));
+    let matches = App::new("rair")
+                    .version(crate_version!())
+                    .version_short("v")
+                    .arg(Arg::with_name("Permission")
+                            .help("File permision: Permission can be R or RW case insensitive, the default is R")
+                            .short("p")
+                            .long("perm")
+                            .takes_value(true))
+                    .arg(Arg::with_name("Paddr")
+                            .help("Physical Base address")
+                            .short("P")
+                            .long("phy")
+                            .takes_value(true))
+                    .arg(Arg::with_name("File")
+                            .help("Binary file to be loaded")
+                            .takes_value(true)
+                            .required(true))
+                      .get_matches();
+    let mut core = Core::new();
+    let mut perm: IoMode = IoMode::READ;
+    let mut paddr :u64 = 0;
+    let uri = matches.value_of("File").unwrap();
+    if let Some(p) = matches.value_of("Permission") {
+        perm = Default::default() ;
+        for c in p. to_lowercase().chars() {
+            match c {
+                'R' => perm |= IoMode::READ,
+                'W' => perm |= IoMode::WRITE,
+                _ => panic!("Unknown Permission: `{}`", c),
+            }
+        }
+    }
+    if let Some(addr) = matches.value_of("Paddr") {
+        paddr = str_to_num(addr).unwrap_or_else(|e| panic!(e.to_string()));
+    }
+    core.io.open_at(uri, perm, paddr).unwrap_or_else(|e| panic!(e.to_string()));
+    core.cur = paddr;
 }

--- a/test_file/Cargo.toml
+++ b/test_file/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_file"
+version = "0.1.0"
+authors = ["oddcoder <ahmedsoliman@oddcoder.com>"]
+license = "LGPL"
+repository = "https://github.com/oddcoder/rair"
+keywords = ["Temp File", "Unit testing", "Address Space"]
+description = "IO subsystem for RAIR"
+categories = ["Testing"]
+readme = "readme.md"
+
+
+
+[dependencies]
+tempfile = "3.1.0"

--- a/test_file/readme.md
+++ b/test_file/readme.md
@@ -1,0 +1,4 @@
+test_file
+=========
+
+Random Temporary files for unit testing.

--- a/test_file/src/lib.rs
+++ b/test_file/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * test_aids.rs: helping function for unit testing.
+ * file_test.rs: Library for aiding unit testing Rair IO.
  * Copyright (C) 2019  Oddcoder
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,6 +14,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+extern crate tempfile;
+
 use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
@@ -25,9 +28,10 @@ pub const DATA: &[u8] = &[
     0x80, 0x41, 0xc1, 0x02, 0xc3, 0xc5, 0x88, 0x4d, 0xd5,
 ];
 
+
 pub fn operate_on_file(test_function: &dyn Fn(&Path), data: &[u8]) {
     let mut file = NamedTempFile::new().unwrap();
-    file.write(data).unwrap();
+    file.write_all(data).unwrap();
     test_function(file.path());
 }
 
@@ -37,24 +41,10 @@ pub fn operate_on_files(test_function: &dyn Fn(&[&Path]), files_data: &[&[u8]]) 
     // This suck! the 2 loops thing, but rust compiler didn't let me do otherwise.
     for i in 0..files_data.len() {
         files.push(NamedTempFile::new().unwrap());
-        files[i].write(files_data[i]).unwrap();
+        files[i].write_all(files_data[i]).unwrap();
     }
     for file in &files {
         paths.push(file.path());
     }
     test_function(&paths);
 }
-
-/*pub fn operate_on_files(test_function: &dyn Fn(&[&Path]), files_data: &[&[u8]]) {
-    let mut files: Vec<NamedTempFile> = Vec::with_capacity(files_data.len());
-    let mut paths: Vec<&Path> = Vec::with_capacity(files_data.len());
-    for data in files_data {
-        let mut file = NamedTempFile::new().unwrap();
-        file.write(data).unwrap();
-
-        paths.push(file.path());
-        files.push(file);
-    }
-    test_function(&paths);
-}
-*/

--- a/test_file/src/lib.rs
+++ b/test_file/src/lib.rs
@@ -28,7 +28,6 @@ pub const DATA: &[u8] = &[
     0x80, 0x41, 0xc1, 0x02, 0xc3, 0xc5, 0x88, 0x4d, 0xd5,
 ];
 
-
 pub fn operate_on_file(test_function: &dyn Fn(&Path), data: &[u8]) {
     let mut file = NamedTempFile::new().unwrap();
     file.write_all(data).unwrap();


### PR DESCRIPTION
Needed to Be done

- [x] get rid of crate `color-backtrace`
- [x] `map` command for mapping from phy to vir.
- [x] Autocomplete.
- [x] full auto coloring Input and output.
- [x] pipe `|` needs to be able to take arguments for the sake of grep.
- [x] seek history.
- [x] get rid of `panic!`.
- [x] `px` command needs to be able to display even if there is gaps.
- [ ] Coverage > 90 %.
- ~`source` command that loads rr files as rair script/config files  #44.~
- ~automatic loading of config files #44.~
- ~ability to pipe/redirect stderr.~
- ~program variables like color theme needs to be accessible via global configuration like `e` in radare2.~
