### PR TITLE
Added SIMD-accelerated restricted Damerau-Levenshtein distance for BK-tree

### DIFF
--- a/rtrees/Cargo.toml
+++ b/rtrees/Cargo.toml
@@ -16,7 +16,7 @@ serialize = ["serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true}
-triple_accel = "0.2.0"
+triple_accel = "0.2.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/rtrees/Cargo.toml
+++ b/rtrees/Cargo.toml
@@ -16,6 +16,7 @@ serialize = ["serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true}
+triple_accel = "0.2.0"
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
I have modified your code to use a SIMD-accelerated version of the OSA distance. It passes all tests, but OSA is not a metric so the BK-tree may produce wrong results. It is better to use Levenshtein distance instead. I can edit the code to do that if you want.