### PR TITLE
skeleton of the command to load scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Rair Core
+
+
+Thank you for your interest in making Rair Core a better library! We are glad that someone somewhere
+shares our enthusiasm and passion for creating state of art reverse engineering platform.
+
+
+First: if you're unsure or *afraid* of anything, just ask or submit the issue or pull request anyway.
+You won't be yelled at for giving it your best effort. The worst that can happen is that you'll be
+politely asked to change something. We appreciate any sort of contributions and don't want a wall
+of rules to get in the way of that.
+
+However, by trying to follow the guidelines in this file, you would make it easier for us to review
+your pull request and merge it quickly with little to no extra effort on your end.
+
+## But why too many guidelines, I just made a POC and want it merged
+
+In our experience, we believe that people are ultimately more excited towards adding new feature rather
+than fixing a bug in an already existing feature. Maintenance is boring business, so we try to make sure
+that every line of code added to rair-core repository would require very little maintenance and is more
+likely to be bugs free.
+
+
+Before submitting a pull request please make sure to:
+
+a) Run `cargo fmt` on all your code
+
+b) Run `cargo clippy` and verify that no warnings are reported
+
+c) Any user-facing API should have at least documentation. It would be better if doctests are provided as well
+
+d) Please split your code into self-contained commits. Ideally, each commit should do one and only one thing.
+
+e) Commits titles should descriptive and in a commanding tone. It should feel like you are giving the commit
+an order to do something like `Convert rair-core into lock-free, mutex free, concurrent data structure`.
+
+f) All newly added code must be well tested. We use code coverage as a metric. A general rule of thumb is that coverage
+should never go down, unless there is a good reason (bug in the coverage tool is the only good reason we ever
+encountered).
+

--- a/rair-io/src/desc.rs
+++ b/rair-io/src/desc.rs
@@ -17,6 +17,8 @@
 use crate::plugin::*;
 use crate::utils::*;
 use serde::{Deserialize, Serialize};
+
+/// This struct represents a file that is opened in [RIO]
 #[derive(Serialize, Deserialize)]
 pub struct RIODesc {
     pub(crate) name: String,

--- a/rair-io/src/io.rs
+++ b/rair-io/src/io.rs
@@ -35,6 +35,10 @@ use std::sync::Arc;
 //          methods that you can use with #[serde(with = ..)]. here I'm using
 //          it to just move the methods from a trait impl you can't wrap or
 //          override to separate functions you can
+//
+/// [RIO] is abstraction over IO, It allows you to open (more than one) file each with its own
+/// encoding in one address space, which you can read / write or map parts of without knowing
+/// which file is really being accessed
 #[derive(Default, Serialize, Deserialize)]
 #[serde(remote = "RIO")]
 pub struct RIO {
@@ -43,6 +47,7 @@ pub struct RIO {
     #[serde(skip)]
     plugins: Vec<Box<dyn RIOPlugin + Sync + Send>>,
 }
+
 impl Serialize for RIO {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -51,6 +56,7 @@ impl Serialize for RIO {
         RIO::serialize(&self, serializer)
     }
 }
+
 impl<'de> Deserialize<'de> for RIO {
     fn deserialize<D>(d: D) -> Result<RIO, D::Error>
     where
@@ -355,7 +361,7 @@ impl RIO {
     pub fn map_iter<'a>(&'a self) -> Box<dyn Iterator<Item = Arc<RIOMap>> + 'a> {
         self.maps.into_iter()
     }
-    // Return equivalent [RIODesc] structure for the given *hndl*
+    /// Return equivalent [RIODesc] structure for the given *hndl*
     pub fn hndl_to_desc(&self, hndl: u64) -> Option<&RIODesc> {
         self.descs.hndl_to_desc(hndl)
     }

--- a/rair-io/src/lib.rs
+++ b/rair-io/src/lib.rs
@@ -1,15 +1,6 @@
 #![warn(clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]
-#![warn(
-    future_incompatible,
-    nonstandard_style,
-    warnings,
-    rust_2018_idioms,
-    unused,
-    rust_2018_idioms,
-    //missing_docs
-)]
-
+#![warn(future_incompatible, nonstandard_style, warnings, rust_2018_idioms, unused, rust_2018_idioms, missing_docs)]
 /*
  * rio: rair IO library impelementation
  * Copyright (C) 2019  Oddcoder
@@ -26,7 +17,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+//! Rair IO abstraction layer
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/rair-io/src/mapsquery.rs
+++ b/rair-io/src/mapsquery.rs
@@ -20,10 +20,15 @@ use serde::{Deserialize, Serialize};
 use std::cmp::min;
 use std::sync::Arc;
 
+/// This struct describes a mapping between physical
+/// address space and virtual address space
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct RIOMap {
+    /// physical address space
     pub paddr: u64,
+    /// virtual address space
     pub vaddr: u64,
+    /// size of the mapping
     pub size: u64,
 }
 

--- a/rair-io/src/plugin.rs
+++ b/rair-io/src/plugin.rs
@@ -16,30 +16,55 @@
  */
 use crate::utils::*;
 
+/// Metadata that describes the plugin
 #[derive(PartialEq)]
 pub struct RIOPluginMetadata {
+    /// Name of the plugin
     pub name: &'static str,
+    /// Short description of the plugin
     pub desc: &'static str,
+    /// Name of the author of the plugin
     pub author: &'static str,
+    /// License of the plugin
     pub license: &'static str,
+    /// Version of the plugin
     pub version: &'static str,
 }
+
+/// This class is populated via [RIOPlugin::open]
 pub struct RIOPluginDesc {
+    /// URI to be opened
     pub name: String,
+    /// Permissions which is opened with
     pub perm: IoMode,
+    /// real base physical address of the file
     pub raddr: u64, //padd is simulated physical address
+    /// Size of the file
     pub size: u64,
+    /// object that implements read/write on the file
     pub plugin_operations: Box<dyn RIOPluginOperations + Sync + Send>,
 }
 
+/// This trait should be implemented by object that allows plugin to open files or check metadata
+/// of the plugin.
 pub trait RIOPlugin {
+    /// Retrieve reference to the plugin metadata
     fn get_metadata(&self) -> &'static RIOPluginMetadata;
+    /// Open a file given a uri (extension://file path) using the mode specified by flags.
     fn open(&mut self, uri: &str, flags: IoMode) -> Result<RIOPluginDesc, IoError>;
+    /// Check if the given file can be opened wit the current plugin (only by checking the uri
+    /// without opening the file)
     fn accept_uri(&self, uri: &str) -> bool;
 }
-
+/// A call to [RIOPlugin::open] would normally return [RioPluginDesc] that contains member that
+/// implements [RIOPluginOperations]. This way we always have way of reading and writing from file
+/// with custom data encoding.
 pub trait RIOPluginOperations {
+    /// Function that read from a file represented by an object opened
+    /// by [RIOPlugin::open] raddr is the real address of the in the file.
     fn read(&mut self, raddr: usize, buffer: &mut [u8]) -> Result<(), IoError>;
+    /// Function that writes to a file represented by an object opened
+    /// by [RIOPlugin::open] raddr is the real address of the in the file.
     fn write(&mut self, raddr: usize, buffer: &[u8]) -> Result<(), IoError>;
 }
 

--- a/rair-io/src/utils.rs
+++ b/rair-io/src/utils.rs
@@ -31,7 +31,6 @@ bitflags! {
     }
 }
 
-
 /// Errors resultion from operations on [RIO]
 #[derive(Debug)]
 pub enum IoError {

--- a/rair-io/src/utils.rs
+++ b/rair-io/src/utils.rs
@@ -19,22 +19,35 @@ use std::fmt;
 use std::io;
 
 bitflags! {
+    /// Set the mode for opening files.
     #[derive(Default, Serialize, Deserialize)]
     pub struct IoMode: u64 {
+    /// Open File in read mode.
     const WRITE = 2;
+    /// Open file in write mode.
     const READ = 4;
+    /// Open file in Copy-On-Write mode.
     const COW = 8;
     }
 }
 
+
+/// Errors resultion from operations on [RIO]
 #[derive(Debug)]
 pub enum IoError {
+    /// Reading or writing to an invalid address.
     AddressNotFound,
+    /// Memory addresses gets mapped in way that makes them overlap
     AddressesOverlapError,
+    /// There is no sutiable IO plugin for loading the given file encoding
     IoPluginNotFoundError,
+    /// Doing operationg on file handles that doesn't exist
     HndlNotFoundError,
+    /// Too many files are opened.
     TooManyFilesError,
+    /// Custom error message.
     Custom(String),
+    /// Error that is originating from [std::io]
     Parse(io::Error),
 }
 impl PartialEq for IoError {

--- a/rtrees/Cargo.toml
+++ b/rtrees/Cargo.toml
@@ -16,7 +16,7 @@ serialize = ["serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true}
-triple_accel = "0.2.0"
+triple_accel = "0.2.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/rtrees/Cargo.toml
+++ b/rtrees/Cargo.toml
@@ -16,6 +16,7 @@ serialize = ["serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true}
+triple_accel = "0.2.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/rtrees/src/bktree/tree.rs
+++ b/rtrees/src/bktree/tree.rs
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-use std::cmp::min;
 use std::collections::HashMap;
 
 // SIMD-accelerated edit distance routines
@@ -146,11 +145,7 @@ mod bktree_tests {
     use super::*;
     #[test]
     fn test_dl_distance() {
-        let s = [
-            ("hello world", "hello world", 0),
-            ("hello world", "hello world ", 1),
-            ("hello world", "h ello World", 2),
-        ];
+        let s = [("hello world", "hello world", 0), ("hello world", "hello world ", 1), ("hello world", "h ello World", 2)];
         for (s1, s2, d) in s.iter() {
             assert_eq!(levenshtein_exp(s1.as_bytes(), s2.as_bytes()) as u64, *d);
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -19,6 +19,7 @@ use crate::commands::Commands;
 use crate::helper::*;
 use crate::io::*;
 use crate::loc::*;
+use crate::utils::command_line_utils;
 use crate::utils::register_utils;
 use crate::writer::Writer;
 use parking_lot::{Mutex, RwLock};
@@ -74,6 +75,7 @@ impl Core {
         register_io(self);
         register_loc(self);
         register_utils(self);
+        command_line_utils(self);
     }
     /// Returns list of all available commands in [Core].
     pub fn commands(&mut self) -> Arc<Mutex<Commands>> {
@@ -221,7 +223,7 @@ mod test_core {
         assert_eq!(core.stdout.utf8_string().unwrap(), "");
         assert_eq!(
             core.stderr.utf8_string().unwrap(),
-            "Error: Execution failed\nCommand mep is not found.\nSimilar command: map, maps, m, e, er, eh.\n"
+            "Error: Execution failed\nCommand mep is not found.\nSimilar command: map, maps, m, e, er, eh, es.\n"
         );
     }
 }

--- a/src/utils/cmd.rs
+++ b/src/utils/cmd.rs
@@ -1,0 +1,71 @@
+/*
+ * cmd.rs: commands for handling another commands.
+ * Copyright (C) 2020  gogo
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use crate::core::*;
+use crate::helper::*;
+use std::fs::File;
+use std::path::Path;
+
+#[derive(Default)]
+pub struct ExecuteScript {}
+
+impl ExecuteScript {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Cmd for ExecuteScript {
+    fn run(&mut self, core: &mut Core, args: &[String]) {
+        if args.len() != 1 {
+            expect(core, args.len() as u64, 1);
+            return;
+        }
+        let path = Path::new(&args[0]);
+        let display = path.display();
+
+        let _script_file = match File::open(&path) {
+            Err(why) => return error_msg(core, &format!("Failed to load file {}.", &display), &why.to_string()),
+            Ok(script_file) => script_file,
+        };
+    }
+    fn help(&self, core: &mut Core) {
+        help(core, &"executeScript", &"es", vec![("[file].rr", "execute each command coded in [file] script.")]);
+    }
+}
+
+#[cfg(test)]
+mod test_cmd {
+    use super::*;
+    use crate::writer::*;
+    use rair_env::Environment as Env;
+    #[test]
+    fn test_help() {
+        let mut core = Core::new_no_colors();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.help("es");
+    }
+
+    #[test]
+    fn test_cmd_help() {
+        let mut core = Core::new_no_colors();
+        core.stderr = Writer::new_buf();
+        core.stdout = Writer::new_buf();
+        core.run("es", &["no utils/unit-tests.rr".to_string()]);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,10 +14,12 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+mod cmd;
 mod env;
 mod project;
 mod quit;
 
+pub use self::cmd::*;
 use self::env::*;
 use self::project::*;
 pub use self::quit::Quit;
@@ -33,4 +35,8 @@ pub fn register_utils(core: &mut Core) {
     core.add_command("environmentReset", "er", Arc::new(Mutex::new(EnvironmentReset::new())));
     let eh = Arc::new(Mutex::new(EnvironmentHelp::new(core)));
     core.add_command("environmentHelp", "eh", eh);
+}
+
+pub fn command_line_utils(core: &mut Core) {
+    core.add_command("executeScript", "es", Arc::new(Mutex::new(ExecuteScript::new())));
 }


### PR DESCRIPTION
This PR does not do nothing interesting for the moment. It is just to show. Next I will implement the run: [see](https://github.com/Rair-Project/rair-core/compare/master...gogo2464:gogo/2_Add-command-for-loading-script-files?expand=1#diff-df186358b1dffce0133defc6b9ef7019R35).

I should have done:

`core.add_command("executeScript", "es", Arc::new(Mutex::new(ExecuteScript:new())));` instead. I will fix it as soon as possible.